### PR TITLE
Fix custom category delete feedback

### DIFF
--- a/app/[locale]/(dashboard)/categories/page.tsx
+++ b/app/[locale]/(dashboard)/categories/page.tsx
@@ -19,6 +19,7 @@ import { useCategories, useCreateCategory, useUpdateCategory, useDeleteCategory 
 import { Category, CategoryFormData, CategoryType } from '@/types';
 import { useI18n } from '@/locales/client';
 import { getCategoryDisplayName } from '@/lib/category-utils';
+import { toast } from 'sonner';
 
 export default function CategoriesPage() {
   const t = useI18n();
@@ -64,10 +65,21 @@ export default function CategoriesPage() {
 
   const handleConfirmDelete = () => {
     if (categoryToDelete) {
+      const categoryName = getCategoryDisplayName(categoryToDelete, t);
+
       deleteMutation.mutate(categoryToDelete.id, {
         onSuccess: () => {
           setDeleteDialogOpen(false);
           setCategoryToDelete(null);
+          toast.success(t('categories_delete_success', { name: categoryName }));
+        },
+        onError: (error) => {
+          const message = error instanceof Error ? error.message : '';
+          const errorMessage = message === 'Cannot delete this category because it is used by existing transactions.'
+            ? t('categories_delete_in_use_error')
+            : message || t('categories_delete_error');
+
+          toast.error(errorMessage);
         },
       });
     }

--- a/app/api/categories/[id]/route.ts
+++ b/app/api/categories/[id]/route.ts
@@ -117,7 +117,7 @@ export async function DELETE(
 
     if (categoryTransactions.length > 0) {
       return NextResponse.json({
-        error: 'Cannot delete category with existing transactions'
+        error: 'Cannot delete this category because it is used by existing transactions.'
       }, { status: 409 });
     }
 

--- a/hooks/useCategories.ts
+++ b/hooks/useCategories.ts
@@ -56,7 +56,8 @@ async function deleteCategory(id: string): Promise<{ success: boolean }> {
   });
 
   if (!response.ok) {
-    throw new Error('Failed to delete category');
+    const errorData = await response.json().catch(() => ({ error: 'Failed to delete category' }));
+    throw new Error(errorData.error || 'Failed to delete category');
   }
 
   return response.json();

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -228,6 +228,10 @@ export default {
     'Are you sure you want to delete the category "{name}"? This action cannot be undone.',
   categories_delete: "Delete",
   categories_deleting: "Deleting...",
+  categories_delete_success: 'Category "{name}" deleted successfully.',
+  categories_delete_error: "Failed to delete category.",
+  categories_delete_in_use_error:
+    "Cannot delete this category because it is used by existing transactions.",
 
   // Currencies
   currency_eur: "Euro - €",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -232,6 +232,10 @@ export default {
     'Êtes-vous sûr de vouloir supprimer la catégorie "{name}" ? Cette action ne peut pas être annulée.',
   categories_delete: "Supprimer",
   categories_deleting: "Suppression...",
+  categories_delete_success: 'Catégorie "{name}" supprimée avec succès.',
+  categories_delete_error: "Échec de la suppression de la catégorie.",
+  categories_delete_in_use_error:
+    "Impossible de supprimer cette catégorie car elle est utilisée par des transactions existantes.",
 
   // Currencies
   currency_eur: "Euro - €",


### PR DESCRIPTION
## Summary
- Parse category delete API errors and surface them in the UI
- Show success/error Sonner toasts for custom category deletion
- Keep blocking deletion for categories used by existing transactions
- Add English and French i18n messages for delete feedback

## Test Plan
- npm run type-check
- npm run lint