### PR TITLE
refactor: migrate icons to Hugeicons

### DIFF
--- a/app/[locale]/(auth)/layout.tsx
+++ b/app/[locale]/(auth)/layout.tsx
@@ -1,8 +1,9 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import { GithubIcon } from "@hugeicons/core-free-icons";
 import { Mascot } from '@/components/shared/Mascot';
 import { getI18n } from '@/locales/server';
 import { LocaleSwitcher } from '@/components/shared/LocaleSwitcher';
 import { ThemeSwitcher } from '@/components/shared/ThemeSwitcher';
-import { Github } from 'lucide-react';
 import Link from 'next/link';
 
 export default async function AuthLayout({
@@ -42,7 +43,7 @@ export default async function AuthLayout({
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors text-sm"
             >
-              <Github className="h-4 w-4" />
+              <HugeiconsIcon icon={GithubIcon} className="h-4 w-4" />
               <span>Open Source on GitHub</span>
             </Link>
           </div>

--- a/app/[locale]/(dashboard)/categories/page.tsx
+++ b/app/[locale]/(dashboard)/categories/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Add01Icon, Delete02Icon, Edit01Icon, Tag01Icon } from "@hugeicons/core-free-icons";
 import { useState } from 'react';
-import { Plus, Edit, Trash2, Tag } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import {
@@ -119,7 +120,7 @@ export default function CategoriesPage() {
             onClick={() => setIsFormOpen(true)}
             className="w-full shadow-card hover:shadow-lg sm:w-auto"
           >
-            <Plus className="mr-2 size-4" />
+            <HugeiconsIcon icon={Add01Icon} className="mr-2 size-4" />
             {t('categories_add_button')}
           </Button>
         }
@@ -198,7 +199,7 @@ export default function CategoriesPage() {
           {customCats.length === 0 ? (
             <div className="text-center py-8 md:py-12">
               <div className="w-10 h-10 md:w-12 md:h-12 bg-muted/50 rounded-full flex items-center justify-center mx-auto mb-2 md:mb-3">
-                <Tag className="h-5 w-5 md:h-6 md:w-6 text-muted-foreground/60" />
+                <HugeiconsIcon icon={Tag01Icon} className="h-5 w-5 md:h-6 md:w-6 text-muted-foreground/60" />
               </div>
               <p className="text-xs md:text-sm text-muted-foreground font-medium">{t('categories_no_custom')}</p>
               <p className="text-xs text-muted-foreground mt-1">
@@ -234,7 +235,7 @@ export default function CategoriesPage() {
                       onClick={() => handleEditCategory(category)}
                       className="h-7 w-7 md:h-8 md:w-8 p-0 hover:bg-primary/10 hover:text-primary"
                     >
-                      <Edit className="h-3 w-3 md:h-3.5 md:w-3.5" />
+                      <HugeiconsIcon icon={Edit01Icon} className="h-3 w-3 md:h-3.5 md:w-3.5" />
                     </Button>
                     <Button
                       size="sm"
@@ -243,7 +244,7 @@ export default function CategoriesPage() {
                       disabled={deleteMutation.isPending}
                       className="h-7 w-7 md:h-8 md:w-8 p-0 hover:bg-destructive/10 hover:text-destructive"
                     >
-                      <Trash2 className="h-3 w-3 md:h-3.5 md:w-3.5" />
+                      <HugeiconsIcon icon={Delete02Icon} className="h-3 w-3 md:h-3.5 md:w-3.5" />
                     </Button>
                   </div>
                 </div>

--- a/app/[locale]/(dashboard)/lists/[id]/page.tsx
+++ b/app/[locale]/(dashboard)/lists/[id]/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Add01Icon, ArrowLeft01Icon, CircleIcon, Delete02Icon, Edit01Icon, Tick01Icon, UserIcon } from "@hugeicons/core-free-icons";
 import { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { Plus, Check, Edit, ArrowLeft, Circle, User, Trash2 } from 'lucide-react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -209,7 +210,7 @@ export default function ListDetailPage() {
       <div className="flex items-center gap-3">
         <Link href={`/${locale}/lists`}>
           <Button variant="ghost" size="sm" className="cursor-pointer p-2">
-            <ArrowLeft className="h-4 w-4" />
+            <HugeiconsIcon icon={ArrowLeft01Icon} className="h-4 w-4" />
           </Button>
         </Link>
         <div
@@ -237,7 +238,7 @@ export default function ListDetailPage() {
             onClick={() => setIsEditingList(true)}
             className="cursor-pointer p-2 hidden sm:inline-flex"
           >
-            <Edit className="h-4 w-4" />
+            <HugeiconsIcon icon={Edit01Icon} className="h-4 w-4" />
           </Button>
           <Button
             variant="outline"
@@ -245,7 +246,7 @@ export default function ListDetailPage() {
             onClick={handleDeleteList}
             className="cursor-pointer p-2 hidden sm:inline-flex hover:bg-destructive/10 hover:text-destructive"
           >
-            <Trash2 className="h-4 w-4" />
+            <HugeiconsIcon icon={Delete02Icon} className="h-4 w-4" />
           </Button>
           <Button
             onClick={handleAddItem}
@@ -253,7 +254,7 @@ export default function ListDetailPage() {
             className="cursor-pointer text-sm px-3 py-2 disabled:cursor-not-allowed"
             size="sm"
           >
-            <Plus className="h-4 w-4 sm:mr-2" />
+            <HugeiconsIcon icon={Add01Icon} className="h-4 w-4 sm:mr-2" />
             <span className="hidden sm:inline">{t('lists_detail_add_item') || 'Add Item'}</span>
           </Button>
         </div>
@@ -294,7 +295,7 @@ export default function ListDetailPage() {
         <Card>
           <CardContent className="p-4">
             <div className="text-center py-4">
-              <Circle className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
+              <HugeiconsIcon icon={CircleIcon} className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
               <h3 className="font-medium mb-2">{t('lists_no_category_title') || 'No Category Assigned'}</h3>
               <p className="text-sm text-muted-foreground mb-4">
                 {t('lists_no_category_description') || 'This list needs a category before you can add items to it.'}
@@ -305,7 +306,7 @@ export default function ListDetailPage() {
                 size="sm"
                 className="cursor-pointer"
               >
-                <Edit className="h-4 w-4 mr-2" />
+                <HugeiconsIcon icon={Edit01Icon} className="h-4 w-4 mr-2" />
                 {t('lists_assign_category') || 'Assign Category'}
               </Button>
             </div>
@@ -368,21 +369,21 @@ export default function ListDetailPage() {
                         )}
                         {item.createdBy && (
                           <div className="flex items-center gap-1">
-                            <User className="h-3 w-3" />
+                            <HugeiconsIcon icon={UserIcon} className="h-3 w-3" />
                             <span>{item.createdBy.name}</span>
                           </div>
                         )}
                       </div>
                       {item.isChecked && (
                         <div className="flex items-center gap-2">
-                          <Check className="h-4 w-4 text-primary shrink-0" />
+                          <HugeiconsIcon icon={Tick01Icon} className="h-4 w-4 text-primary shrink-0" />
                           <Button
                             variant="ghost"
                             size="sm"
                             onClick={(e) => handleDeleteItem(item.id, e)}
                             className="h-6 w-6 p-0 hover:bg-destructive/10 hover:text-destructive"
                           >
-                            <Trash2 className="h-3 w-3" />
+                            <HugeiconsIcon icon={Delete02Icon} className="h-3 w-3" />
                           </Button>
                         </div>
                       )}
@@ -393,10 +394,10 @@ export default function ListDetailPage() {
             </div>
           ) : (
             <div className="text-center py-8">
-              <Circle className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+              <HugeiconsIcon icon={CircleIcon} className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
               <p className="text-muted-foreground mb-4">{t('lists_detail_no_items') || 'No items in this list yet'}</p>
               <Button onClick={handleAddItem} className="cursor-pointer">
-                <Plus className="h-4 w-4 mr-2" />
+                <HugeiconsIcon icon={Add01Icon} className="h-4 w-4 mr-2" />
                 {t('lists_detail_add_first_item') || 'Add your first item'}
               </Button>
             </div>

--- a/app/[locale]/(dashboard)/lists/page.tsx
+++ b/app/[locale]/(dashboard)/lists/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Add01Icon, CheckListIcon, CircleIcon, ShoppingCart01Icon } from "@hugeicons/core-free-icons";
 import { useState } from 'react';
-import { Plus, ClipboardList, Circle, ShoppingCart } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useCurrentLocale, useI18n } from '@/locales/client';
@@ -116,7 +117,7 @@ export default function ListsPage() {
             onClick={handleCreateList}
             className="w-full cursor-pointer shadow-card hover:shadow-lg sm:w-auto"
           >
-            <Plus className="mr-2 size-4" />
+            <HugeiconsIcon icon={Add01Icon} className="mr-2 size-4" />
             {t('lists_create')}
           </Button>
         }
@@ -126,7 +127,7 @@ export default function ListsPage() {
       {lists.length === 0 ? (
         <div className="text-center py-12 md:py-16">
           <div className="w-16 h-16 md:w-20 md:h-20 bg-muted/50 rounded-full flex items-center justify-center mx-auto mb-4 md:mb-6">
-            <ClipboardList className="h-8 w-8 md:h-10 md:w-10 text-muted-foreground" />
+            <HugeiconsIcon icon={CheckListIcon} className="h-8 w-8 md:h-10 md:w-10 text-muted-foreground" />
           </div>
           <h3 className="text-lg md:text-xl font-semibold mb-2">
             {t('lists_empty_title') || 'No lists yet'}
@@ -135,7 +136,7 @@ export default function ListsPage() {
             {t('lists_empty_description') || 'Create your first shopping list to start organizing your potential purchases.'}
           </p>
           <Button onClick={handleCreateList} className="cursor-pointer">
-            <Plus className="h-4 w-4 mr-2" />
+            <HugeiconsIcon icon={Add01Icon} className="h-4 w-4 mr-2" />
             {t('lists_create_first') || 'Create your first list'}
           </Button>
         </div>
@@ -199,7 +200,7 @@ export default function ListsPage() {
                     <div className="grid grid-cols-2 gap-4 pt-2 border-t border-border/50">
                       <div className="text-center">
                         <div className="flex items-center justify-center gap-1 text-muted-foreground mb-1">
-                          <Circle className="h-3 w-3" />
+                          <HugeiconsIcon icon={CircleIcon} className="h-3 w-3" />
                           <span className="text-xs font-medium">
                             {t('lists_remaining') || 'Remaining'}
                           </span>
@@ -211,7 +212,7 @@ export default function ListsPage() {
 
                       <div className="text-center">
                         <div className="flex items-center justify-center gap-1 text-muted-foreground mb-1">
-                          <ShoppingCart className="h-3 w-3" />
+                          <HugeiconsIcon icon={ShoppingCart01Icon} className="h-3 w-3" />
                           <span className="text-xs font-medium">
                             {t('lists_estimated') || 'Estimated'}
                           </span>

--- a/app/[locale]/(dashboard)/profile/page.tsx
+++ b/app/[locale]/(dashboard)/profile/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { HugeiconsIcon, type IconSvgElement } from '@hugeicons/react';
+import { Alert01Icon, AnalyticsUpIcon, ArrowRight01Icon, Coins01Icon, Delete02Icon, FloppyDiskIcon, LanguageCircleIcon, MoonIcon, Tag01Icon } from "@hugeicons/core-free-icons";
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
@@ -7,7 +9,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { Trash2, Save, AlertTriangle, ChevronRight, Tag, TrendingUp, Languages, Moon, Coins } from 'lucide-react';
 import { LocaleSwitcher } from '@/components/shared/LocaleSwitcher';
 import { ThemeSwitcher } from '@/components/shared/ThemeSwitcher';
 import { UserAvatar } from '@/components/shared/UserAvatar';
@@ -85,7 +86,7 @@ function SettingsRow({
   right,
   destructive,
 }: {
-  icon: React.ComponentType<{ className?: string }>;
+  icon: IconSvgElement;
   tint?: keyof typeof rowTints;
   title: string;
   subtitle?: string;
@@ -98,13 +99,13 @@ function SettingsRow({
   const inner = (
     <div className={`flex items-center gap-3 px-4 py-3.5 ${interactive ? 'hover:bg-primary/5 transition-colors' : ''}`}>
       <div className={`flex items-center justify-center w-10 h-10 rounded-lg shrink-0 ${rowTints[tint]}`}>
-        <Icon className="h-5 w-5" />
+        <HugeiconsIcon icon={Icon} className="h-5 w-5" />
       </div>
       <div className="flex-1 min-w-0">
         <p className={`text-sm font-medium truncate ${destructive ? 'text-destructive' : 'text-foreground'}`}>{title}</p>
         {subtitle && <p className="text-xs text-muted-foreground truncate">{subtitle}</p>}
       </div>
-      {right ?? (interactive && <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />)}
+      {right ?? (interactive && <HugeiconsIcon icon={ArrowRight01Icon} className="h-4 w-4 text-muted-foreground shrink-0" />)}
     </div>
   );
   if (href) return <Link href={href} className="block">{inner}</Link>;
@@ -222,7 +223,7 @@ export default function ProfilePage() {
       <div className="flex items-center justify-center min-h-[400px]">
         <Card className="w-full max-w-md border-0 shadow-sm">
           <CardContent className="p-8 text-center">
-            <AlertTriangle className="h-12 w-12 mx-auto mb-4 text-amber-500" />
+            <HugeiconsIcon icon={Alert01Icon} className="h-12 w-12 mx-auto mb-4 text-amber-500" />
             <p className="text-lg font-medium text-foreground">{t('profile_session_expired')}</p>
             <p className="text-sm text-muted-foreground mt-2">
               {t('profile_login_required')}
@@ -296,7 +297,7 @@ export default function ProfilePage() {
             </div>
             <div className="flex justify-end">
               <Button type="submit" disabled={updateProfileMutation.isPending} className="w-full sm:w-auto">
-                <Save className="h-4 w-4 mr-2" />
+                <HugeiconsIcon icon={FloppyDiskIcon} className="h-4 w-4 mr-2" />
                 {updateProfileMutation.isPending ? t('profile_saving') : t('profile_save')}
               </Button>
             </div>
@@ -309,7 +310,7 @@ export default function ProfilePage() {
         <SectionLabel>{t('profile_section_preferences')}</SectionLabel>
         <Panel>
           <SettingsRow
-            icon={Coins}
+            icon={Coins01Icon}
             tint="coral"
             title={t('profile_currency')}
             right={
@@ -327,8 +328,8 @@ export default function ProfilePage() {
               </Select>
             }
           />
-          <SettingsRow icon={Languages} tint="green" title={t('profile_language')} right={<LocaleSwitcher variant="ghost" showText />} />
-          <SettingsRow icon={Moon} tint="blue" title={t('profile_appearance')} right={<ThemeSwitcher />} />
+          <SettingsRow icon={LanguageCircleIcon} tint="green" title={t('profile_language')} right={<LocaleSwitcher variant="ghost" showText />} />
+          <SettingsRow icon={MoonIcon} tint="blue" title={t('profile_appearance')} right={<ThemeSwitcher />} />
         </Panel>
       </section>
 
@@ -336,8 +337,8 @@ export default function ProfilePage() {
       <section className="space-y-3">
         <SectionLabel>{t('profile_section_budget')}</SectionLabel>
         <Panel>
-          <SettingsRow icon={Tag} tint="green" title={t('nav_categories')} href={`/${locale}/categories`} />
-          <SettingsRow icon={TrendingUp} tint="blue" title={t('nav_trends')} href={`/${locale}/trends`} />
+          <SettingsRow icon={Tag01Icon} tint="green" title={t('nav_categories')} href={`/${locale}/categories`} />
+          <SettingsRow icon={AnalyticsUpIcon} tint="blue" title={t('nav_trends')} href={`/${locale}/trends`} />
         </Panel>
       </section>
 
@@ -361,7 +362,7 @@ export default function ProfilePage() {
         <SectionLabel>{t('profile_danger_section')}</SectionLabel>
         <Panel>
           <SettingsRow
-            icon={Trash2}
+            icon={Delete02Icon}
             tint="red"
             title={t('profile_delete_button')}
             subtitle={t('profile_delete_description')}

--- a/app/[locale]/(dashboard)/transactions/page.tsx
+++ b/app/[locale]/(dashboard)/transactions/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Add01Icon, AnalyticsUpIcon, Calendar01Icon, Download01Icon } from "@hugeicons/core-free-icons";
 import { useState } from 'react';
-import { Plus, Calendar, TrendingUp, Download } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsContent } from '@/components/ui/tabs';
@@ -188,7 +189,7 @@ export default function TransactionsPage() {
               disabled={isExporting || isLoadingTransactions || (transactionsData?.transactions?.length ?? 0) === 0}
               className="w-full cursor-pointer sm:w-auto"
             >
-              <Download className="mr-2 size-4" />
+              <HugeiconsIcon icon={Download01Icon} className="mr-2 size-4" />
               {t('export_button')}
             </Button>
             <Button
@@ -196,7 +197,7 @@ export default function TransactionsPage() {
               className="w-full cursor-pointer shadow-card hover:shadow-lg sm:w-auto"
               disabled={isLoadingCategories || categories.length === 0}
             >
-              <Plus className="mr-2 size-4" />
+              <HugeiconsIcon icon={Add01Icon} className="mr-2 size-4" />
               {t('transactions_add_button')}
             </Button>
           </div>
@@ -214,7 +215,7 @@ export default function TransactionsPage() {
                 : 'text-muted-foreground hover:text-foreground'
             }`}
           >
-            <TrendingUp className="h-3.5 w-3.5 inline mr-1.5" />
+            <HugeiconsIcon icon={AnalyticsUpIcon} className="h-3.5 w-3.5 inline mr-1.5" />
             {t('transactions_monthly') || 'Monthly'}
           </button>
           <button
@@ -225,7 +226,7 @@ export default function TransactionsPage() {
                 : 'text-muted-foreground hover:text-foreground'
             }`}
           >
-            <Calendar className="h-3.5 w-3.5 inline mr-1.5" />
+            <HugeiconsIcon icon={Calendar01Icon} className="h-3.5 w-3.5 inline mr-1.5" />
             {t('transactions_annual') || 'Annual'}
           </button>
         </div>

--- a/app/[locale]/(dashboard)/trends/page.tsx
+++ b/app/[locale]/(dashboard)/trends/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { AnalyticsUpIcon, ChartLineData01Icon } from "@hugeicons/core-free-icons";
 import { useState, useMemo } from 'react';
-import { TrendingUp, LineChart as LineChartIcon } from 'lucide-react';
 import {
   Area,
   AreaChart,
@@ -105,7 +106,7 @@ export default function TrendsPage() {
         <Card className="shadow-card">
           <CardContent className="text-center py-12 md:py-16">
             <div className="w-12 h-12 md:w-16 md:h-16 bg-muted/50 rounded-full flex items-center justify-center mx-auto mb-3 md:mb-4">
-              <TrendingUp className="h-6 w-6 md:h-7 md:w-7 text-muted-foreground" />
+              <HugeiconsIcon icon={AnalyticsUpIcon} className="h-6 w-6 md:h-7 md:w-7 text-muted-foreground" />
             </div>
             <p className="font-medium text-sm md:text-base">{t('trends_empty_title')}</p>
             <p className="text-xs md:text-sm text-muted-foreground mt-1">{t('trends_empty_subtitle')}</p>
@@ -117,7 +118,7 @@ export default function TrendsPage() {
           <Card className="shadow-card">
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-base md:text-lg">
-                <LineChartIcon className="h-4 w-4 text-primary" />
+                <HugeiconsIcon icon={ChartLineData01Icon} className="h-4 w-4 text-primary" />
                 {t('trends_balance_title')}
               </CardTitle>
             </CardHeader>
@@ -161,7 +162,7 @@ export default function TrendsPage() {
           <Card className="shadow-card">
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-base md:text-lg">
-                <TrendingUp className="h-4 w-4 text-primary" />
+                <HugeiconsIcon icon={AnalyticsUpIcon} className="h-4 w-4 text-primary" />
                 {t('trends_income_expenses_title')}
               </CardTitle>
             </CardHeader>

--- a/app/[locale]/offline/page.tsx
+++ b/app/[locale]/offline/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Refresh01Icon, WifiOff01Icon } from "@hugeicons/core-free-icons";
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { WifiOff, RefreshCw } from 'lucide-react';
+
 export default function OfflinePage() {
 
   const handleRefresh = () => {
@@ -15,7 +17,7 @@ export default function OfflinePage() {
         <CardContent className="p-8 text-center space-y-6">
           <div className="flex justify-center">
             <div className="w-16 h-16 rounded-full bg-muted/50 flex items-center justify-center">
-              <WifiOff className="h-8 w-8 text-muted-foreground" />
+              <HugeiconsIcon icon={WifiOff01Icon} className="h-8 w-8 text-muted-foreground" />
             </div>
           </div>
 
@@ -38,7 +40,7 @@ export default function OfflinePage() {
               className="w-full"
               variant="default"
             >
-              <RefreshCw className="h-4 w-4 mr-2" />
+              <HugeiconsIcon icon={Refresh01Icon} className="h-4 w-4 mr-2" />
               Try Again
             </Button>
           </div>

--- a/app/partner-invite/[token]/page.tsx
+++ b/app/partner-invite/[token]/page.tsx
@@ -1,10 +1,18 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  AlertCircleIcon,
+  CancelCircleIcon,
+  CheckmarkCircle01Icon,
+  DollarSignIcon,
+  HeartIcon,
+  Loading02Icon,
+} from '@hugeicons/core-free-icons';
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Loader2, CheckCircle, XCircle, AlertCircle, Heart, DollarSign } from 'lucide-react';
 import { toast } from 'sonner';
 
 interface PartnerInvitePageProps {
@@ -78,14 +86,14 @@ export default function PartnerInvitePage({ params }: PartnerInvitePageProps) {
   const getStatusIcon = () => {
     switch (status) {
       case 'loading':
-        return <Heart className="h-12 w-12 text-pink-500" />;
+        return <HugeiconsIcon icon={HeartIcon} className="h-12 w-12 text-pink-500" />;
       case 'success':
-        return <CheckCircle className="h-12 w-12 text-green-500" />;
+        return <HugeiconsIcon icon={CheckmarkCircle01Icon} className="h-12 w-12 text-green-500" />;
       case 'expired':
-        return <AlertCircle className="h-12 w-12 text-yellow-500" />;
+        return <HugeiconsIcon icon={AlertCircleIcon} className="h-12 w-12 text-yellow-500" />;
       case 'error':
       case 'unauthorized':
-        return <XCircle className="h-12 w-12 text-red-500" />;
+        return <HugeiconsIcon icon={CancelCircleIcon} className="h-12 w-12 text-red-500" />;
       default:
         return null;
     }
@@ -135,7 +143,7 @@ export default function PartnerInvitePage({ params }: PartnerInvitePageProps) {
             <div className="space-y-6">
               <div className="bg-slate-800 rounded-lg p-4 space-y-3">
                 <h3 className="text-white font-semibold flex items-center gap-2">
-                  <DollarSign className="h-4 w-4" />
+                  <HugeiconsIcon icon={DollarSignIcon} className="h-4 w-4" />
                   As budget partners, you&apos;ll share:
                 </h3>
                 <ul className="text-sm text-slate-300 space-y-1 text-left">
@@ -153,12 +161,12 @@ export default function PartnerInvitePage({ params }: PartnerInvitePageProps) {
               >
                 {isAccepting ? (
                   <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    <HugeiconsIcon icon={Loading02Icon} className="mr-2 h-4 w-4 animate-spin" />
                     Accepting...
                   </>
                 ) : (
                   <>
-                    <Heart className="mr-2 h-4 w-4" />
+                    <HugeiconsIcon icon={HeartIcon} className="mr-2 h-4 w-4" />
                     Accept Partnership
                   </>
                 )}

--- a/components/dashboard/BalanceCards.tsx
+++ b/components/dashboard/BalanceCards.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { AnalyticsDownIcon, AnalyticsUpIcon, ArrowUpRight01Icon, CircleIcon } from "@hugeicons/core-free-icons";
 import Link from 'next/link';
-import { ArrowUpRight, Circle, TrendingDown, TrendingUp } from 'lucide-react';
 import { useI18n } from '@/locales/client';
 import { MonthlyBalance } from '@/types';
 import { useFormatCurrency } from '@/lib/currency-utils';
@@ -41,7 +42,7 @@ export function BalanceCards({ balance, monthLabel, trendsHref }: BalanceCardsPr
               className="inline-flex shrink-0 items-center gap-2 rounded-full border border-border bg-background/60 px-3 py-2 text-xs font-semibold text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               {t('nav_trends')}
-              <ArrowUpRight className="size-3.5" />
+              <HugeiconsIcon icon={ArrowUpRight01Icon} className="size-3.5" />
             </Link>
           </div>
 
@@ -50,7 +51,7 @@ export function BalanceCards({ balance, monthLabel, trendsHref }: BalanceCardsPr
               {formatCurrency(balance.balance)}
             </p>
             <div className={`mt-3 inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-semibold ${positive ? 'bg-emerald-500/15 text-emerald-500' : 'bg-rose-500/15 text-rose-400'}`}>
-              <Circle className="size-2 fill-current" />
+              <HugeiconsIcon icon={CircleIcon} className="size-2 fill-current" />
               {positive ? t('dashboard_on_track') : t('dashboard_over_budget')}
             </div>
           </div>
@@ -82,7 +83,7 @@ export function BalanceCards({ balance, monthLabel, trendsHref }: BalanceCardsPr
           <div className="flex items-center justify-between gap-3">
             <p className="text-sm font-semibold text-emerald-500">{t('dashboard_income')}</p>
             <div className="flex size-9 items-center justify-center rounded-xl bg-emerald-500/15 text-emerald-500">
-              <TrendingUp className="size-4.5" />
+              <HugeiconsIcon icon={AnalyticsUpIcon} className="size-4.5" />
             </div>
           </div>
           <p className="mt-3 font-display text-2xl font-semibold tracking-tight text-emerald-500 sm:text-3xl">
@@ -94,7 +95,7 @@ export function BalanceCards({ balance, monthLabel, trendsHref }: BalanceCardsPr
           <div className="flex items-center justify-between gap-3">
             <p className="text-sm font-semibold text-rose-400">{t('dashboard_expenses')}</p>
             <div className="flex size-9 items-center justify-center rounded-xl bg-rose-500/15 text-rose-400">
-              <TrendingDown className="size-4.5" />
+              <HugeiconsIcon icon={AnalyticsDownIcon} className="size-4.5" />
             </div>
           </div>
           <p className="mt-3 font-display text-2xl font-semibold tracking-tight text-rose-400 sm:text-3xl">

--- a/components/dashboard/CategoryBreakdown.tsx
+++ b/components/dashboard/CategoryBreakdown.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowDown01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { useState } from 'react';
 import Link from 'next/link';
-import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useTransactions } from '@/hooks/useTransactions';
 import { useI18n } from '@/locales/client';
 import { getCategoryDisplayName } from '@/lib/category-utils';
@@ -83,9 +84,9 @@ export function CategoryBreakdown({
                       <div className="flex min-w-0 flex-1 items-center gap-3 md:gap-4">
                         <div className="flex items-center gap-2 md:gap-3">
                           {isExpanded ? (
-                            <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+                            <HugeiconsIcon icon={ArrowDown01Icon} className="size-4 shrink-0 text-muted-foreground" />
                           ) : (
-                            <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+                            <HugeiconsIcon icon={ArrowRight01Icon} className="size-4 shrink-0 text-muted-foreground" />
                           )}
                           <div
                             className="flex size-6 shrink-0 items-center justify-center rounded-lg md:size-8"

--- a/components/dashboard/DashboardHeader.tsx
+++ b/components/dashboard/DashboardHeader.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Calendar01Icon } from "@hugeicons/core-free-icons";
 import React from 'react';
 import { usePathname } from 'next/navigation';
 import { useCurrentLocale, useI18n } from '@/locales/client';
 import { LocaleSwitcher } from '@/components/shared/LocaleSwitcher';
 import { ThemeSwitcher } from '@/components/shared/ThemeSwitcher';
-import { Calendar } from 'lucide-react';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -107,7 +108,7 @@ export function DashboardHeader() {
 
       <div className="flex items-center gap-3 px-6">
         <div className="hidden select-none items-center gap-2 text-muted-foreground md:flex">
-          <Calendar className="h-3.5 w-3.5 text-muted-foreground" />
+          <HugeiconsIcon icon={Calendar01Icon} className="h-3.5 w-3.5 text-muted-foreground" />
           <span className="text-xs font-medium">
             {new Intl.DateTimeFormat(locale, { month: 'short', year: 'numeric' }).format(new Date())}
           </span>

--- a/components/layout/AppSidebar.tsx
+++ b/components/layout/AppSidebar.tsx
@@ -1,19 +1,20 @@
 "use client";
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ArrowUp01Icon,
+  ChartLineData01Icon,
+  CheckListIcon,
+  CreditCardIcon,
+  DashboardCircleIcon,
+  Logout01Icon,
+  Tag01Icon,
+  UserIcon,
+} from "@hugeicons/core-free-icons";
 import { useRouter, usePathname, useParams } from "next/navigation";
 import Link from "next/link";
 import { Mascot } from "@/components/shared/Mascot";
 import { UserAvatar } from "@/components/shared/UserAvatar";
-import {
-  LayoutDashboard,
-  Tag,
-  LogOut,
-  CreditCard,
-  ClipboardList,
-  LineChart,
-  User,
-  ChevronUp,
-} from "lucide-react";
 import {
   Sidebar,
   SidebarContent,
@@ -51,27 +52,27 @@ export function AppSidebar() {
     {
       title: t("nav_dashboard"),
       url: `/${locale}/dashboard`,
-      icon: LayoutDashboard,
+      icon: DashboardCircleIcon,
     },
     {
       title: t("nav_transactions"),
       url: `/${locale}/transactions`,
-      icon: CreditCard,
+      icon: CreditCardIcon,
     },
     {
       title: t("nav_trends"),
       url: `/${locale}/trends`,
-      icon: LineChart,
+      icon: ChartLineData01Icon,
     },
     {
       title: t("nav_categories"),
       url: `/${locale}/categories`,
-      icon: Tag,
+      icon: Tag01Icon,
     },
     {
       title: t("nav_lists"),
       url: `/${locale}/lists`,
-      icon: ClipboardList,
+      icon: CheckListIcon,
     },
   ];
 
@@ -123,7 +124,8 @@ export function AppSidebar() {
                         }
                       }}
                     >
-                      <item.icon
+                      <HugeiconsIcon
+                        icon={item.icon}
                         className={`h-5 w-5 transition-all duration-200 group-hover:scale-110 ${
                           isActive(item.url)
                             ? "text-primary dark:text-primary-foreground"
@@ -164,7 +166,7 @@ export function AppSidebar() {
                       {session.user.email}
                     </span>
                   </div>
-                  <ChevronUp className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+                  <HugeiconsIcon icon={ArrowUp01Icon} className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent
@@ -190,7 +192,7 @@ export function AppSidebar() {
                       if (isMobile) setOpenMobile(false);
                     }}
                   >
-                    <User className="h-4 w-4 text-muted-foreground" />
+                    <HugeiconsIcon icon={UserIcon} className="h-4 w-4 text-muted-foreground" />
                     {t("nav_profile")}
                   </Link>
                 </DropdownMenuItem>
@@ -198,7 +200,7 @@ export function AppSidebar() {
                   onClick={handleSignOut}
                   className="h-10 cursor-pointer rounded-lg px-2.5 text-destructive focus:text-destructive"
                 >
-                  <LogOut className="h-4 w-4 text-destructive" />
+                  <HugeiconsIcon icon={Logout01Icon} className="h-4 w-4 text-destructive" />
                   {t("nav_signOut")}
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/components/partner-invitation-card.tsx
+++ b/components/partner-invitation-card.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Cancel01Icon, Clock01Icon, HeartIcon, Loading02Icon, Tick01Icon } from '@hugeicons/core-free-icons';
 import React, { useState } from 'react';
 import Image from 'next/image';
-import { Heart, Check, X, Clock, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { toast } from 'sonner';
@@ -140,7 +141,7 @@ export default function PartnerInvitationCard({ invitation, onUpdate }: PartnerI
         <div className="px-6 py-4 border-b border-border bg-muted/20">
           <div className="flex items-center gap-3">
             <div className="w-10 h-10 rounded-xl bg-muted flex items-center justify-center">
-              <Heart className="h-5 w-5 text-muted-foreground" />
+              <HugeiconsIcon icon={HeartIcon} className="h-5 w-5 text-muted-foreground" />
             </div>
             <div>
               <h3 className="font-semibold text-foreground">{t('partner_invitation_title')}</h3>
@@ -182,7 +183,7 @@ export default function PartnerInvitationCard({ invitation, onUpdate }: PartnerI
           {/* Metadata */}
           <div className="flex items-center gap-4 text-xs text-muted-foreground mb-6 p-3 rounded-lg bg-muted/30">
             <div className="flex items-center gap-1.5">
-              <Clock className="h-3 w-3" />
+              <HugeiconsIcon icon={Clock01Icon} className="h-3 w-3" />
               <span>{t('partner_received_time', { time: formatTimeAgo(invitation.createdAt) })}</span>
             </div>
             <div className="flex items-center gap-1.5">
@@ -200,12 +201,12 @@ export default function PartnerInvitationCard({ invitation, onUpdate }: PartnerI
             >
               {isAccepting ? (
                 <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  <HugeiconsIcon icon={Loading02Icon} className="h-4 w-4 mr-2 animate-spin" />
                   {t('partner_accepting')}
                 </>
               ) : (
                 <>
-                  <Check className="h-4 w-4 mr-2" />
+                  <HugeiconsIcon icon={Tick01Icon} className="h-4 w-4 mr-2" />
                   {t('partner_accept_partnership')}
                 </>
               )}
@@ -219,12 +220,12 @@ export default function PartnerInvitationCard({ invitation, onUpdate }: PartnerI
             >
               {isDeclining ? (
                 <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  <HugeiconsIcon icon={Loading02Icon} className="h-4 w-4 mr-2 animate-spin" />
                   {t('partner_declining')}
                 </>
               ) : (
                 <>
-                  <X className="h-4 w-4 mr-2" />
+                  <HugeiconsIcon icon={Cancel01Icon} className="h-4 w-4 mr-2" />
                   {t('partner_decline')}
                 </>
               )}

--- a/components/partner-management.tsx
+++ b/components/partner-management.tsx
@@ -1,21 +1,21 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Alert01Icon,
+  Cancel01Icon,
+  HeartIcon,
+  Loading02Icon,
+  Search01Icon,
+  SentIcon,
+  UserAdd01Icon,
+  UserMultipleIcon,
+  UserRemove01Icon,
+} from '@hugeicons/core-free-icons';
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { 
-  Users2, 
-  Search, 
-  UserPlus, 
-  X, 
-  Heart, 
-  Loader2, 
-  AlertTriangle,
-  Send,
-  UserX
-} from 'lucide-react';
-
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -221,7 +221,7 @@ export default function PartnerManagement({ partnerInfo, sentInvitations, onPart
       <div className="rounded-lg md:rounded-xl border border-border bg-card shadow-card">
         <div className="p-4 md:p-6">
           <div className="flex items-center gap-3 mb-4 md:mb-6">
-            <Users2 className="h-5 w-5 text-muted-foreground" />
+            <HugeiconsIcon icon={UserMultipleIcon} className="h-5 w-5 text-muted-foreground" />
             <h2 className="text-lg md:text-xl font-bold tracking-tight">{t('partner_budget_title')}</h2>
           </div>
 
@@ -239,7 +239,7 @@ export default function PartnerManagement({ partnerInfo, sentInvitations, onPart
                       size={64}
                     />
                     <div className="absolute -top-1 -right-1 w-5 h-5 bg-emerald-500 rounded-full flex items-center justify-center">
-                      <Heart className="h-2.5 w-2.5 text-white fill-current" />
+                      <HugeiconsIcon icon={HeartIcon} className="h-2.5 w-2.5 fill-current text-white" />
                     </div>
                   </div>
                   
@@ -271,7 +271,7 @@ export default function PartnerManagement({ partnerInfo, sentInvitations, onPart
                     onClick={() => setShowRemoveDialog(true)}
                     className="text-muted-foreground hover:text-destructive hover:border-destructive/50 hover:bg-destructive/5 transition-colors"
                   >
-                    <UserX className="h-4 w-4 mr-2" />
+                    <HugeiconsIcon icon={UserRemove01Icon} className="h-4 w-4 mr-2" />
                     {t('partner_stop_sharing')}
                   </Button>
                 </div>
@@ -284,7 +284,7 @@ export default function PartnerManagement({ partnerInfo, sentInvitations, onPart
             // No Partner and no sent invitations
             <div className="px-4 py-6 text-center md:py-8">
               <div className="mx-auto mb-4 flex size-14 items-center justify-center rounded-2xl border border-blue-100 bg-gradient-to-br from-blue-50 to-indigo-50 dark:border-blue-800/30 dark:from-blue-950/20 dark:to-indigo-950/20">
-                <Users2 className="size-7 text-blue-600 dark:text-blue-400" />
+                <HugeiconsIcon icon={UserMultipleIcon} className="size-7 text-blue-600 dark:text-blue-400" />
               </div>
               
               <h3 className="mb-2 text-lg font-semibold text-foreground">
@@ -299,7 +299,7 @@ export default function PartnerManagement({ partnerInfo, sentInvitations, onPart
                 onClick={() => setShowInviteDialog(true)}
                 className="rounded-xl font-medium"
               >
-                <UserPlus className="h-4 w-4 mr-2" />
+                <HugeiconsIcon icon={UserAdd01Icon} className="h-4 w-4 mr-2" />
                 {t('partner_invite_button')}
               </Button>
             </div>
@@ -313,7 +313,7 @@ export default function PartnerManagement({ partnerInfo, sentInvitations, onPart
           <DialogHeader className="text-left space-y-3">
             <DialogTitle className="flex items-center gap-3 text-xl">
               <div className="w-10 h-10 rounded-xl bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
-                <UserPlus className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                <HugeiconsIcon icon={UserAdd01Icon} className="h-5 w-5 text-blue-600 dark:text-blue-400" />
               </div>
               {t('partner_invite_title')}
             </DialogTitle>
@@ -326,7 +326,7 @@ export default function PartnerManagement({ partnerInfo, sentInvitations, onPart
             <div className="space-y-2">
               <Label htmlFor="search">{t('partner_search_label')}</Label>
               <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <HugeiconsIcon icon={Search01Icon} className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
                   id="search"
                   placeholder={t('partner_search_placeholder')}
@@ -334,7 +334,7 @@ export default function PartnerManagement({ partnerInfo, sentInvitations, onPart
                   {...register('query')}
                 />
                 {isSearching && (
-                  <Loader2 className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+                  <HugeiconsIcon icon={Loading02Icon} className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
                 )}
               </div>
               {errors.query && (
@@ -397,7 +397,7 @@ export default function PartnerManagement({ partnerInfo, sentInvitations, onPart
                     }}
                     className="flex-1 h-11 rounded-xl font-medium border-border"
                   >
-                    <X className="h-4 w-4 mr-2" />
+                    <HugeiconsIcon icon={Cancel01Icon} className="h-4 w-4 mr-2" />
                     {t('common_cancel')}
                   </Button>
                   <Button
@@ -407,12 +407,12 @@ export default function PartnerManagement({ partnerInfo, sentInvitations, onPart
                   >
                     {isInviting ? (
                       <>
-                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                        <HugeiconsIcon icon={Loading02Icon} className="h-4 w-4 mr-2 animate-spin" />
                         {t('partner_sending')}
                       </>
                     ) : (
                       <>
-                        <Send className="h-4 w-4 mr-2" />
+                        <HugeiconsIcon icon={SentIcon} className="h-4 w-4 mr-2" />
                         {t('partner_send_invitation')}
                       </>
                     )}
@@ -429,7 +429,7 @@ export default function PartnerManagement({ partnerInfo, sentInvitations, onPart
         <AlertDialogContent className="max-w-lg">
           <AlertDialogHeader>
             <AlertDialogTitle className="text-destructive flex items-center gap-2">
-              <AlertTriangle className="h-5 w-5" />
+              <HugeiconsIcon icon={Alert01Icon} className="h-5 w-5" />
               {t('partner_remove_dialog_title')}
             </AlertDialogTitle>
             <AlertDialogDescription className="space-y-3">
@@ -452,7 +452,7 @@ export default function PartnerManagement({ partnerInfo, sentInvitations, onPart
             >
               {isRemoving ? (
                 <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  <HugeiconsIcon icon={Loading02Icon} className="h-4 w-4 mr-2 animate-spin" />
                   {t('partner_removing')}
                 </>
               ) : (

--- a/components/sent-invitation-card.tsx
+++ b/components/sent-invitation-card.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Cancel01Icon, Clock01Icon, Loading02Icon, SentIcon } from "@hugeicons/core-free-icons";
 import React, { useState } from 'react';
 import Image from 'next/image';
-import { Clock, X, Send, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { toast } from 'sonner';
@@ -110,7 +111,7 @@ export default function SentInvitationCard({ invitation, onUpdate }: SentInvitat
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 rounded-xl bg-muted flex items-center justify-center">
-                <Send className="h-5 w-5 text-muted-foreground" />
+                <HugeiconsIcon icon={SentIcon} className="h-5 w-5 text-muted-foreground" />
               </div>
               <div>
                 <h3 className="font-semibold text-foreground">{t('partner_invitation_sent')}</h3>
@@ -139,7 +140,7 @@ export default function SentInvitationCard({ invitation, onUpdate }: SentInvitat
                 />
               </div>
               <div className="absolute -top-1 -right-1 w-5 h-5 bg-muted-foreground rounded-full flex items-center justify-center">
-                <Clock className="h-2.5 w-2.5 text-background" />
+                <HugeiconsIcon icon={Clock01Icon} className="h-2.5 w-2.5 text-background" />
               </div>
             </div>
             
@@ -159,7 +160,7 @@ export default function SentInvitationCard({ invitation, onUpdate }: SentInvitat
           {/* Metadata */}
           <div className="flex items-center gap-4 text-xs text-muted-foreground mb-6 p-3 rounded-lg bg-muted/30">
             <div className="flex items-center gap-1.5">
-              <Clock className="h-3 w-3" />
+              <HugeiconsIcon icon={Clock01Icon} className="h-3 w-3" />
               <span>{t('partner_sent_time', { time: formatTimeAgo(invitation.createdAt) })}</span>
             </div>
             <div className="flex items-center gap-1.5">
@@ -178,12 +179,12 @@ export default function SentInvitationCard({ invitation, onUpdate }: SentInvitat
             >
               {isCancelling ? (
                 <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  <HugeiconsIcon icon={Loading02Icon} className="h-4 w-4 mr-2 animate-spin" />
                   {t('partner_cancelling')}
                 </>
               ) : (
                 <>
-                  <X className="h-4 w-4 mr-2" />
+                  <HugeiconsIcon icon={Cancel01Icon} className="h-4 w-4 mr-2" />
                   {t('partner_cancel_invitation')}
                 </>
               )}

--- a/components/shared/LocaleSwitcher.tsx
+++ b/components/shared/LocaleSwitcher.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { LanguageCircleIcon } from "@hugeicons/core-free-icons";
 import { useCurrentLocale, useChangeLocale } from '@/locales/client';
 import { Button } from '@/components/ui/button';
 import {
@@ -8,8 +10,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Languages } from 'lucide-react';
-
 const locales = [
   { code: 'en', name: 'English', flag: '🇺🇸' },
   { code: 'fr', name: 'Français', flag: '🇫🇷' },
@@ -56,7 +56,7 @@ export function LocaleSwitcher({
                 {currentLocaleData?.name}
               </span>
             )}
-            <Languages className="h-4 w-4" />
+            <HugeiconsIcon icon={LanguageCircleIcon} className="h-4 w-4" />
           </div>
         </Button>
       </DropdownMenuTrigger>

--- a/components/shared/ThemeSwitcher.tsx
+++ b/components/shared/ThemeSwitcher.tsx
@@ -1,8 +1,8 @@
 "use client"
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { MoonIcon, Sun01Icon } from "@hugeicons/core-free-icons";
 import * as React from "react"
-import { Moon, Sun } from "lucide-react"
-
 import { Button } from "@/components/ui/button"
 import { useTheme } from "@/components/theme-provider"
 
@@ -30,8 +30,8 @@ export function ThemeSwitcher() {
       onClick={() => setTheme(theme === "light" ? "dark" : "light")}
       className="w-9 h-9"
     >
-      <Moon className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-      <Sun className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <HugeiconsIcon icon={MoonIcon} className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <HugeiconsIcon icon={Sun01Icon} className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
       <span className="sr-only">Toggle theme</span>
     </Button>
   )

--- a/components/transactions/AnnualTransactionList.tsx
+++ b/components/transactions/AnnualTransactionList.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Calendar01Icon, Delete02Icon, Edit01Icon } from "@hugeicons/core-free-icons";
 import { useState } from 'react';
-import { Edit, Trash2, Calendar } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   AlertDialog,
@@ -83,7 +84,7 @@ export function AnnualTransactionList({
           </h2>
           <div className="text-center py-6 md:py-8">
             <div className="w-10 h-10 md:w-12 md:h-12 bg-muted/50 rounded-full flex items-center justify-center mx-auto mb-2 md:mb-3">
-              <Calendar className="h-5 w-5 md:h-6 md:w-6 text-muted-foreground" />
+              <HugeiconsIcon icon={Calendar01Icon} className="h-5 w-5 md:h-6 md:w-6 text-muted-foreground" />
             </div>
             <p className="text-xs md:text-sm text-muted-foreground font-medium">
               {hasPartner ? t('transactions_no_shared_annual') : t('transactions_no_annual')}
@@ -134,7 +135,7 @@ export function AnnualTransactionList({
                         <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3">
                           <span className="truncate">{getCategoryDisplayName(transaction.category, t)}</span>
                           <div className="flex items-center gap-1 shrink-0">
-                            <Calendar className="h-3 w-3" />
+                            <HugeiconsIcon icon={Calendar01Icon} className="h-3 w-3" />
                             <span className="text-blue-600 dark:text-blue-400 font-medium">
                               {t('transaction_renews_in') || 'Renews in'} {renewalMonth}
                             </span>
@@ -160,7 +161,7 @@ export function AnnualTransactionList({
                           onClick={() => onEdit(transaction)}
                           className="h-7 w-7 md:h-8 md:w-8 p-0 hover:bg-primary/10 hover:text-primary cursor-pointer"
                         >
-                          <Edit className="h-3 w-3 md:h-3.5 md:w-3.5" />
+                          <HugeiconsIcon icon={Edit01Icon} className="h-3 w-3 md:h-3.5 md:w-3.5" />
                         </Button>
                         <Button
                           size="sm"
@@ -169,7 +170,7 @@ export function AnnualTransactionList({
                           disabled={isDeleting}
                           className="h-7 w-7 md:h-8 md:w-8 p-0 hover:bg-destructive/10 hover:text-destructive cursor-pointer"
                         >
-                          <Trash2 className="h-3 w-3 md:h-3.5 md:w-3.5" />
+                          <HugeiconsIcon icon={Delete02Icon} className="h-3 w-3 md:h-3.5 md:w-3.5" />
                         </Button>
                       </div>
                     )}

--- a/components/transactions/TransactionList.tsx
+++ b/components/transactions/TransactionList.tsx
@@ -1,9 +1,10 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Calendar01Icon, Clock01Icon, Delete02Icon, Edit01Icon, RepeatIcon, UserIcon } from "@hugeicons/core-free-icons";
 import { useState } from 'react';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
-import { Edit, Trash2, Calendar, Repeat, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   AlertDialog,
@@ -53,7 +54,7 @@ export function TransactionList({
       return { 
         type: 'annual', 
         text: t('transaction_recurring_annual') || 'Annual', 
-        icon: Calendar, 
+        icon: Calendar01Icon,
         color: 'text-muted-foreground/70' 
       };
     }
@@ -70,17 +71,17 @@ export function TransactionList({
     if (endDate) {
       const diffMonths = (endDate.getFullYear() - now.getFullYear()) * 12 + (endDate.getMonth() - now.getMonth());
       if (diffMonths <= 0) {
-        return { type: 'ended', text: t('transaction_recurring_ended') || 'Ended', icon: Clock, color: 'text-muted-foreground' };
+        return { type: 'ended', text: t('transaction_recurring_ended') || 'Ended', icon: Clock01Icon, color: 'text-muted-foreground' };
       } else if (diffMonths <= 12) {
         const remainingText = diffMonths === 1 
           ? t('transaction_recurring_last_month') || '1 month left'
           : `${diffMonths} ${t('months') || 'months'} ${t('transaction_recurring_left') || 'left'}`;
-        return { type: 'limited', text: remainingText, icon: Clock, color: 'text-orange-600 dark:text-orange-400' };
+        return { type: 'limited', text: remainingText, icon: Clock01Icon, color: 'text-orange-600 dark:text-orange-400' };
       }
     }
     
     // Forever recurring
-    return { type: 'forever', text: t('transaction_recurring_monthly') || 'Monthly', icon: Repeat, color: 'text-blue-600 dark:text-blue-400' };
+    return { type: 'forever', text: t('transaction_recurring_monthly') || 'Monthly', icon: RepeatIcon, color: 'text-blue-600 dark:text-blue-400' };
   };
 
   const filteredTransactions = transactions.filter(
@@ -163,13 +164,13 @@ export function TransactionList({
                           <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3">
                             <span className="truncate italic">{t('transaction_private_category') || 'Private category'}</span>
                             <div className="flex items-center gap-1 shrink-0">
-                              <Calendar className="h-3 w-3" />
+                              <HugeiconsIcon icon={Calendar01Icon} className="h-3 w-3" />
                               <span>{format(new Date(transaction.date), 'dd/MM', { locale: fr })}</span>
                             </div>
                           </div>
                           {transaction.createdBy && hasPartner && (
                             <div className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
-                              <User className="h-3 w-3" />
+                              <HugeiconsIcon icon={UserIcon} className="h-3 w-3" />
                               <span className="font-medium">{t('transaction_created_by')} {transaction.createdBy.name}</span>
                             </div>
                           )}
@@ -182,13 +183,13 @@ export function TransactionList({
                           <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3">
                             <span className="truncate">{getCategoryDisplayName(transaction.category, t)}</span>
                             <div className="flex items-center gap-1 shrink-0">
-                              <Calendar className="h-3 w-3" />
+                              <HugeiconsIcon icon={Calendar01Icon} className="h-3 w-3" />
                               <span>{format(new Date(transaction.date), 'dd/MM', { locale: fr })}</span>
                             </div>
                           </div>
                           {transaction.createdBy && hasPartner && (
                             <div className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
-                              <User className="h-3 w-3" />
+                              <HugeiconsIcon icon={UserIcon} className="h-3 w-3" />
                               <span className="font-medium">{t('transaction_created_by')} {transaction.createdBy.name}</span>
                             </div>
                           )}
@@ -196,10 +197,9 @@ export function TransactionList({
                             const recurringInfo = getRecurringInfo(transaction);
                             if (!recurringInfo) return null;
                             
-                            const Icon = recurringInfo.icon;
                             return (
                               <div className={`flex items-center gap-1 ${recurringInfo.color}`}>
-                                <Icon className="h-3 w-3" />
+                                <HugeiconsIcon icon={recurringInfo.icon} className="h-3 w-3" />
                                 <span className="font-medium">{recurringInfo.text}</span>
                               </div>
                             );
@@ -226,7 +226,7 @@ export function TransactionList({
                         onClick={() => onEdit(transaction)}
                         className="h-7 w-7 md:h-8 md:w-8 p-0 hover:bg-primary/10 hover:text-primary cursor-pointer"
                       >
-                        <Edit className="h-3 w-3 md:h-3.5 md:w-3.5" />
+                        <HugeiconsIcon icon={Edit01Icon} className="h-3 w-3 md:h-3.5 md:w-3.5" />
                       </Button>
                       <Button
                         size="sm"
@@ -235,7 +235,7 @@ export function TransactionList({
                         disabled={isDeleting}
                         className="h-7 w-7 md:h-8 md:w-8 p-0 hover:bg-destructive/10 hover:text-destructive cursor-pointer"
                       >
-                        <Trash2 className="h-3 w-3 md:h-3.5 md:w-3.5" />
+                        <HugeiconsIcon icon={Delete02Icon} className="h-3 w-3 md:h-3.5 md:w-3.5" />
                       </Button>
                     </div>
                   )}

--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -1,7 +1,7 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowRight01Icon, MoreHorizontalIcon } from "@hugeicons/core-free-icons";
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { ChevronRight, MoreHorizontal } from "lucide-react"
-
 import { cn } from "@/lib/utils"
 
 function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
@@ -75,7 +75,7 @@ function BreadcrumbSeparator({
       className={cn("[&>svg]:size-3.5", className)}
       {...props}
     >
-      {children ?? <ChevronRight />}
+      {children ?? <HugeiconsIcon icon={ArrowRight01Icon} />}
     </li>
   )
 }
@@ -92,7 +92,7 @@ function BreadcrumbEllipsis({
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontal className="size-4" />
+      <HugeiconsIcon icon={MoreHorizontalIcon} className="size-4" />
       <span className="sr-only">More</span>
     </span>
   )

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,9 +1,9 @@
 "use client"
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Tick01Icon } from "@hugeicons/core-free-icons";
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { CheckIcon } from "lucide-react"
-
 import { cn } from "@/lib/utils"
 
 function Checkbox({
@@ -23,7 +23,7 @@ function Checkbox({
         data-slot="checkbox-indicator"
         className="flex items-center justify-center text-current transition-none"
       >
-        <CheckIcon className="size-3.5" />
+        <HugeiconsIcon icon={Tick01Icon} className="size-3.5" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,9 +1,9 @@
 "use client"
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
-
 import { cn } from "@/lib/utils"
 
 function Dialog({
@@ -71,7 +71,7 @@ function DialogContent({
             data-slot="dialog-close"
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
-            <XIcon />
+            <HugeiconsIcon icon={Cancel01Icon} />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,9 +1,9 @@
 "use client"
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowRight01Icon, CircleIcon, Tick01Icon } from "@hugeicons/core-free-icons";
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
-
 import { cn } from "@/lib/utils"
 
 function DropdownMenu({
@@ -100,7 +100,7 @@ function DropdownMenuCheckboxItem({
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
+          <HugeiconsIcon icon={Tick01Icon} className="size-4" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -135,7 +135,7 @@ function DropdownMenuRadioItem({
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="size-2 fill-current" />
+          <HugeiconsIcon icon={CircleIcon} className="size-2 fill-current" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -217,7 +217,7 @@ function DropdownMenuSubTrigger({
       {...props}
     >
       {children}
-      <ChevronRightIcon className="ml-auto size-4" />
+      <HugeiconsIcon icon={ArrowRight01Icon} className="ml-auto size-4" />
     </DropdownMenuPrimitive.SubTrigger>
   )
 }

--- a/components/ui/language-switcher.tsx
+++ b/components/ui/language-switcher.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { LanguageCircleIcon } from "@hugeicons/core-free-icons";
 import { useCurrentLocale, useChangeLocale } from '@/locales/client';
 import { Button } from '@/components/ui/button';
 import {
@@ -8,8 +10,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Languages } from 'lucide-react';
-
 const languages = [
   { code: 'fr', name: 'Français', flag: '🇫🇷' },
   { code: 'en', name: 'English', flag: '🇺🇸' },
@@ -36,7 +36,7 @@ export function LanguageSwitcher() {
           size="sm" 
           className="h-10 px-3 touch-manipulation active:scale-95 transition-transform"
         >
-          <Languages className="h-4 w-4 mr-2" />
+          <HugeiconsIcon icon={LanguageCircleIcon} className="h-4 w-4 mr-2" />
           <span className="text-sm">{currentLanguage?.flag}</span>
         </Button>
       </DropdownMenuTrigger>

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,9 +1,9 @@
 "use client"
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowDown01Icon, ArrowUp01Icon, Tick01Icon } from "@hugeicons/core-free-icons";
 import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
-
 import { cn } from "@/lib/utils"
 
 function Select({
@@ -44,7 +44,7 @@ function SelectTrigger({
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <ChevronDownIcon className="size-4 opacity-50" />
+        <HugeiconsIcon icon={ArrowDown01Icon} className="size-4 opacity-50" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   )
@@ -114,7 +114,7 @@ function SelectItem({
     >
       <span className="absolute right-2 flex size-3.5 items-center justify-center">
         <SelectPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
+          <HugeiconsIcon icon={Tick01Icon} className="size-4" />
         </SelectPrimitive.ItemIndicator>
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
@@ -148,7 +148,7 @@ function SelectScrollUpButton({
       )}
       {...props}
     >
-      <ChevronUpIcon className="size-4" />
+      <HugeiconsIcon icon={ArrowUp01Icon} className="size-4" />
     </SelectPrimitive.ScrollUpButton>
   )
 }
@@ -166,7 +166,7 @@ function SelectScrollDownButton({
       )}
       {...props}
     >
-      <ChevronDownIcon className="size-4" />
+      <HugeiconsIcon icon={ArrowDown01Icon} className="size-4" />
     </SelectPrimitive.ScrollDownButton>
   )
 }

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,9 +1,9 @@
 "use client"
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
-
 import { cn } from "@/lib/utils"
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
@@ -73,7 +73,7 @@ function SheetContent({
       >
         {children}
         <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-          <XIcon className="size-4" />
+          <HugeiconsIcon icon={Cancel01Icon} className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -1,10 +1,10 @@
 "use client"
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { PanelLeftIcon } from "@hugeicons/core-free-icons";
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, VariantProps } from "class-variance-authority"
-import { PanelLeftIcon } from "lucide-react"
-
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -273,7 +273,7 @@ function SidebarTrigger({
       }}
       {...props}
     >
-      <PanelLeftIcon />
+      <HugeiconsIcon icon={PanelLeftIcon} />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@better-auth/expo": "^1.3.8",
         "@hookform/resolvers": "^5.2.1",
+        "@hugeicons/core-free-icons": "^4.2.2",
+        "@hugeicons/react": "^1.1.9",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -29,7 +31,6 @@
         "drizzle-kit": "^0.31.4",
         "drizzle-orm": "^0.44.5",
         "exceljs": "^4.4.0",
-        "lucide-react": "^0.542.0",
         "next": "15.5.9",
         "next-international": "^1.3.1",
         "next-pwa": "^5.6.0",
@@ -2691,6 +2692,21 @@
       },
       "peerDependencies": {
         "react-hook-form": "^7.55.0"
+      }
+    },
+    "node_modules/@hugeicons/core-free-icons": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@hugeicons/core-free-icons/-/core-free-icons-4.2.2.tgz",
+      "integrity": "sha512-fjQW3p6cwoJmwK3oCnV8Z3PC5sHihDvr2jkAHax8cxqp62GaV/D7B/Rnao+JwicW8fmLZUQ6QrzWfoyMFOEQlQ==",
+      "license": "MIT"
+    },
+    "node_modules/@hugeicons/react": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@hugeicons/react/-/react-1.1.9.tgz",
+      "integrity": "sha512-O+lWSWjbijoAvMCxn4K2bQWCGN5+mP1y5j+X99j23mXMj+s0X25fs71T6t9YJLaBodwmZdaewD27dzS/PiboQw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -10597,15 +10613,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
-    },
-    "node_modules/lucide-react": {
-      "version": "0.542.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
-      "integrity": "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/magic-string": {
       "version": "0.30.18",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "dependencies": {
     "@better-auth/expo": "^1.3.8",
     "@hookform/resolvers": "^5.2.1",
+    "@hugeicons/core-free-icons": "^4.2.2",
+    "@hugeicons/react": "^1.1.9",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
@@ -39,7 +41,6 @@
     "drizzle-kit": "^0.31.4",
     "drizzle-orm": "^0.44.5",
     "exceljs": "^4.4.0",
-    "lucide-react": "^0.542.0",
     "next": "15.5.9",
     "next-international": "^1.3.1",
     "next-pwa": "^5.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.1
         version: 5.4.0(react-hook-form@7.81.0(react@19.1.0))
+      '@hugeicons/core-free-icons':
+        specifier: ^4.2.2
+        version: 4.2.2
+      '@hugeicons/react':
+        specifier: ^1.1.9
+        version: 1.1.9(react@19.1.0)
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -71,9 +77,6 @@ importers:
       exceljs:
         specifier: ^4.4.0
         version: 4.4.0
-      lucide-react:
-        specifier: ^0.542.0
-        version: 0.542.0(react@19.1.0)
       next:
         specifier: 15.5.9
         version: 15.5.9(@babel/core@7.29.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1292,6 +1295,14 @@ packages:
     resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
     peerDependencies:
       react-hook-form: ^7.55.0
+
+  '@hugeicons/core-free-icons@4.2.2':
+    resolution: {integrity: sha512-fjQW3p6cwoJmwK3oCnV8Z3PC5sHihDvr2jkAHax8cxqp62GaV/D7B/Rnao+JwicW8fmLZUQ6QrzWfoyMFOEQlQ==}
+
+  '@hugeicons/react@1.1.9':
+    resolution: {integrity: sha512-O+lWSWjbijoAvMCxn4K2bQWCGN5+mP1y5j+X99j23mXMj+s0X25fs71T6t9YJLaBodwmZdaewD27dzS/PiboQw==}
+    peerDependencies:
+      react: '>=16.0.0'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -4001,11 +4012,6 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.542.0:
-    resolution: {integrity: sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
 
@@ -6180,6 +6186,12 @@ snapshots:
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.81.0(react@19.1.0)
+
+  '@hugeicons/core-free-icons@4.2.2': {}
+
+  '@hugeicons/react@1.1.9(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -8860,10 +8872,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lucide-react@0.542.0(react@19.1.0):
-    dependencies:
-      react: 19.1.0
 
   magic-string@0.25.9:
     dependencies:


### PR DESCRIPTION
## Summary
- replace Lucide React icons across application screens, navigation, partner flows, and shared UI primitives
- add the official Hugeicons React renderer and free stroke-rounded icon pack
- update dynamic icon rendering for settings, navigation, and recurring transaction states
- remove the Lucide dependency and synchronize npm and pnpm lockfiles

## Validation
- npm run type-check
- npx eslint app components
- npm run build:local
- git diff --check
- verified zero remaining Lucide source or lockfile references

## Notes
- the migration uses direct named icon imports for tree shaking
- unrelated local Apple-auth work in lib/auth.ts was intentionally excluded