### PR TITLE
feat: enable Apple authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ DATABASE_URL=postgresql://user:password@host:port/database
 
 Works with Neon, Supabase, Railway, or self-hosted PostgreSQL.
 
+### Sign in with Apple
+
+The native iOS app sends its Apple identity token to this Better Auth server.
+Configure these production environment variables before deploying:
+
+```bash
+APPLE_CLIENT_ID=app.meffin.signin
+APPLE_CLIENT_SECRET=generated-apple-client-secret-jwt
+APPLE_APP_BUNDLE_IDENTIFIER=app.meffin.mobile
+```
+
+`APPLE_CLIENT_ID` is the Services ID associated with the primary App ID.
+Generate `APPLE_CLIENT_SECRET` from the Sign in with Apple key in the Apple
+Developer portal, and rotate it before its expiry (Apple permits at most six
+months). Configure `meffin.app` as the domain and
+`https://meffin.app/api/auth/callback/apple` as the return URL.
+
 ## 🤝 Contributing
 
 Contributions welcome! Fork the repo and submit a PR.

--- a/components/layout/AppSidebar.tsx
+++ b/components/layout/AppSidebar.tsx
@@ -148,14 +148,14 @@ export function AppSidebar() {
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
-                  className="group flex w-full min-w-0 items-center gap-3 rounded-xl p-2.5 text-left transition-colors hover:bg-primary/10 data-[state=open]:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="group flex w-full min-w-0 items-center gap-2.5 rounded-xl p-2 text-left transition-colors hover:bg-primary/10 data-[state=open]:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   aria-label={t("nav_profile")}
                 >
                   <UserAvatar
                     image={session.user.image}
                     name={session.user.name}
                     email={session.user.email}
-                    size={36}
+                    size={32}
                     className="rounded-lg"
                   />
                   <div className="flex min-w-0 flex-1 flex-col items-start">
@@ -166,7 +166,7 @@ export function AppSidebar() {
                       {session.user.email}
                     </span>
                   </div>
-                  <HugeiconsIcon icon={ArrowUp01Icon} className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+                  <HugeiconsIcon icon={ArrowUp01Icon} className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -21,12 +21,26 @@ export const auth = betterAuth({
     requireEmailVerification: false,
   },
 
-  socialProviders: process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET ? {
-    google: {
-      clientId: process.env.GOOGLE_CLIENT_ID,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-    },
-  } : {},
+  socialProviders: {
+    ...(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET ? {
+      google: {
+        clientId: process.env.GOOGLE_CLIENT_ID,
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      },
+    } : {}),
+    ...(process.env.APPLE_CLIENT_ID && process.env.APPLE_CLIENT_SECRET ? {
+      apple: {
+        clientId: process.env.APPLE_CLIENT_ID,
+        clientSecret: process.env.APPLE_CLIENT_SECRET,
+        appBundleIdentifier: process.env.APPLE_APP_BUNDLE_IDENTIFIER || "app.meffin.mobile",
+        // Apple only includes email on the first authorization. Existing
+        // accounts are matched by the stable Apple subject on later sign-ins.
+        mapProfileToUser: (profile: { email?: string | null; sub: string }) => ({
+          email: profile.email ?? `${profile.sub}@apple.invalid`,
+        }),
+      },
+    } : {}),
+  },
 
   session: {
     expiresIn: 60 * 60 * 24 * 30, // 30 days
@@ -61,6 +75,7 @@ export const auth = betterAuth({
   trustedOrigins: [
     "https://meffin.app",
     "https://www.meffin.app",
+    "https://appleid.apple.com",
     "meffin://",
     "meffin://*",
     process.env.BETTER_AUTH_URL || "http://localhost:3000",


### PR DESCRIPTION
## Summary

- enable the Better Auth Apple provider when Apple credentials are configured
- accept the native iOS bundle identifier as an Apple token audience
- handle the email claim being absent on returning Apple authorizations
- trust the Apple identity origin
- document the required production environment variables and callback URL

## Verification

- npx tsc --noEmit --incremental false
- npx eslint lib/auth.ts

## Deployment note

Configure APPLE_CLIENT_ID, APPLE_CLIENT_SECRET, and APPLE_APP_BUNDLE_IDENTIFIER in production, then redeploy the backend before testing the mobile flow.