### PR TITLE
Add privacy and terms pages

### DIFF
--- a/app/[locale]/privacy/page.tsx
+++ b/app/[locale]/privacy/page.tsx
@@ -1,0 +1,181 @@
+import type { Metadata } from "next";
+import { LegalShell, type LegalSection } from "@/components/legal/legal-shell";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy - Meffin",
+  description: "How Meffin collects, uses, and protects your data.",
+};
+
+type Content = {
+  title: string;
+  updated: string;
+  intro: string;
+  backLabel: string;
+  sections: LegalSection[];
+};
+
+const content: Record<"en" | "fr", Content> = {
+  en: {
+    title: "Privacy Policy",
+    updated: "Last updated: July 19, 2026",
+    backLabel: "← Back to Meffin",
+    intro:
+      "Meffin is a simple monthly budget tracker. This policy explains what we collect, why, and what you can do about it. We keep it short because we collect little.",
+    sections: [
+      {
+        heading: "What we collect",
+        bullets: [
+          "Account details: your name and email address. If you sign in with Google or Apple, we receive these from them. Apple may give you a private relay email instead of your real one — that still works.",
+          "Your budget data: the transactions, amounts, categories, lists, currency, and language you add to Meffin.",
+          "If you share a budget with a partner, the data you share becomes visible to them.",
+          "Basic technical data needed to keep you signed in, such as a session cookie. We don't run third-party ad or analytics trackers.",
+        ],
+      },
+      {
+        heading: "How we use it",
+        bullets: [
+          "To run the app: store your budget, sync it across your devices, and sign you in.",
+          "To keep your account secure.",
+          "We do not sell your data, and we don't use it for advertising.",
+        ],
+      },
+      {
+        heading: "Who we share it with",
+        bullets: [
+          "A partner you choose to share a budget with.",
+          "Infrastructure providers that host the app and database on our behalf. They process data only to run the service.",
+          "Authorities, if the law requires it.",
+        ],
+      },
+      {
+        heading: "How long we keep it",
+        paragraphs: [
+          "We keep your data while your account is active. When you delete your account from the app, your data — transactions, lists, and categories — is permanently removed. This can't be undone.",
+        ],
+      },
+      {
+        heading: "Your choices",
+        bullets: [
+          "See and edit your data any time inside the app.",
+          "Export your transactions as a spreadsheet.",
+          "Delete your account, and everything with it, from the profile screen.",
+        ],
+      },
+      {
+        heading: "Security",
+        paragraphs: [
+          "Passwords are hashed, connections are encrypted in transit, and sign-in is handled by trusted providers. No system is perfect, but we take reasonable steps to protect your data.",
+        ],
+      },
+      {
+        heading: "Children",
+        paragraphs: [
+          "Meffin isn't meant for children under 13, and we don't knowingly collect their data.",
+        ],
+      },
+      {
+        heading: "Changes",
+        paragraphs: [
+          "If we change this policy, we'll update the date at the top and note significant changes in the app.",
+        ],
+      },
+      {
+        heading: "Contact",
+        paragraphs: [
+          "Questions or requests about your data? Email us at support@meffin.app.",
+        ],
+      },
+    ],
+  },
+  fr: {
+    title: "Politique de confidentialité",
+    updated: "Dernière mise à jour : 19 juillet 2026",
+    backLabel: "← Retour à Meffin",
+    intro:
+      "Meffin est une application simple de suivi de budget mensuel. Cette politique explique ce que nous collectons, pourquoi, et ce que vous pouvez y faire. Elle est courte parce que nous collectons peu.",
+    sections: [
+      {
+        heading: "Ce que nous collectons",
+        bullets: [
+          "Vos informations de compte : nom et adresse e-mail. Si vous vous connectez avec Google ou Apple, nous les recevons de leur part. Apple peut vous fournir une adresse relais privée plutôt que la vôtre — cela fonctionne aussi.",
+          "Vos données de budget : les transactions, montants, catégories, listes, devise et langue que vous ajoutez dans Meffin.",
+          "Si vous partagez un budget avec un partenaire, les données partagées lui deviennent visibles.",
+          "Des données techniques de base nécessaires pour vous garder connecté, comme un cookie de session. Nous n'utilisons pas de traqueurs publicitaires ou d'analyse tiers.",
+        ],
+      },
+      {
+        heading: "Comment nous les utilisons",
+        bullets: [
+          "Pour faire fonctionner l'application : enregistrer votre budget, le synchroniser entre vos appareils et vous connecter.",
+          "Pour sécuriser votre compte.",
+          "Nous ne vendons pas vos données et ne les utilisons pas à des fins publicitaires.",
+        ],
+      },
+      {
+        heading: "Avec qui nous les partageons",
+        bullets: [
+          "Un partenaire avec qui vous choisissez de partager un budget.",
+          "Les prestataires d'infrastructure qui hébergent l'application et la base de données pour notre compte. Ils traitent les données uniquement pour faire fonctionner le service.",
+          "Les autorités, si la loi l'exige.",
+        ],
+      },
+      {
+        heading: "Combien de temps nous les conservons",
+        paragraphs: [
+          "Nous conservons vos données tant que votre compte est actif. Lorsque vous supprimez votre compte depuis l'application, vos données — transactions, listes et catégories — sont définitivement effacées. Cette action est irréversible.",
+        ],
+      },
+      {
+        heading: "Vos choix",
+        bullets: [
+          "Consulter et modifier vos données à tout moment dans l'application.",
+          "Exporter vos transactions sous forme de tableur.",
+          "Supprimer votre compte, et tout ce qu'il contient, depuis l'écran de profil.",
+        ],
+      },
+      {
+        heading: "Sécurité",
+        paragraphs: [
+          "Les mots de passe sont hachés, les connexions sont chiffrées en transit et la connexion est gérée par des prestataires de confiance. Aucun système n'est parfait, mais nous prenons des mesures raisonnables pour protéger vos données.",
+        ],
+      },
+      {
+        heading: "Enfants",
+        paragraphs: [
+          "Meffin n'est pas destiné aux enfants de moins de 13 ans, et nous ne collectons pas sciemment leurs données.",
+        ],
+      },
+      {
+        heading: "Modifications",
+        paragraphs: [
+          "Si nous modifions cette politique, nous mettrons à jour la date en haut et signalerons les changements importants dans l'application.",
+        ],
+      },
+      {
+        heading: "Contact",
+        paragraphs: [
+          "Des questions ou des demandes concernant vos données ? Écrivez-nous à support@meffin.app.",
+        ],
+      },
+    ],
+  },
+};
+
+export default async function PrivacyPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const c = content[locale === "fr" ? "fr" : "en"];
+  return (
+    <LegalShell
+      locale={locale}
+      title={c.title}
+      updated={c.updated}
+      intro={c.intro}
+      sections={c.sections}
+      backLabel={c.backLabel}
+    />
+  );
+}

--- a/app/[locale]/terms/page.tsx
+++ b/app/[locale]/terms/page.tsx
@@ -1,0 +1,171 @@
+import type { Metadata } from "next";
+import { LegalShell, type LegalSection } from "@/components/legal/legal-shell";
+
+export const metadata: Metadata = {
+  title: "Terms of Service - Meffin",
+  description: "The terms for using Meffin.",
+};
+
+type Content = {
+  title: string;
+  updated: string;
+  intro: string;
+  backLabel: string;
+  sections: LegalSection[];
+};
+
+const content: Record<"en" | "fr", Content> = {
+  en: {
+    title: "Terms of Service",
+    updated: "Last updated: July 19, 2026",
+    backLabel: "← Back to Meffin",
+    intro:
+      "These terms cover your use of Meffin. By using the app, you agree to them.",
+    sections: [
+      {
+        heading: "Using Meffin",
+        paragraphs: [
+          "Meffin is a personal budgeting app. We grant you a personal, non-transferable right to use it. Don't misuse it, try to break it, or use it to break the law.",
+        ],
+      },
+      {
+        heading: "Your account",
+        bullets: [
+          "You're responsible for your account and for keeping your sign-in secure.",
+          "Give accurate information when you sign up.",
+          "You must be at least 13 years old to use Meffin.",
+        ],
+      },
+      {
+        heading: "Your data is yours",
+        paragraphs: [
+          "You own the budget data you put into Meffin. You can export or delete it at any time. We only use it to provide the service, as described in the Privacy Policy.",
+        ],
+      },
+      {
+        heading: "Availability",
+        paragraphs: [
+          "We work to keep Meffin running, but we can't promise it will always be available or error-free. We may change or discontinue features.",
+        ],
+      },
+      {
+        heading: "As is",
+        paragraphs: [
+          'Meffin is provided "as is," without warranties of any kind. It\'s a budgeting tool, not financial advice.',
+        ],
+      },
+      {
+        heading: "Limitation of liability",
+        paragraphs: [
+          "To the extent the law allows, we aren't liable for any indirect or incidental damages arising from your use of Meffin.",
+        ],
+      },
+      {
+        heading: "Ending your use",
+        paragraphs: [
+          "You can stop using Meffin and delete your account at any time. We may suspend accounts that break these terms.",
+        ],
+      },
+      {
+        heading: "Changes",
+        paragraphs: [
+          "We may update these terms. We'll change the date above and note significant changes in the app. Continuing to use Meffin means you accept the update.",
+        ],
+      },
+      {
+        heading: "Governing law",
+        paragraphs: ["These terms are governed by the laws of France."],
+      },
+      {
+        heading: "Contact",
+        paragraphs: ["Questions? Email support@meffin.app."],
+      },
+    ],
+  },
+  fr: {
+    title: "Conditions d'utilisation",
+    updated: "Dernière mise à jour : 19 juillet 2026",
+    backLabel: "← Retour à Meffin",
+    intro:
+      "Ces conditions encadrent votre utilisation de Meffin. En utilisant l'application, vous les acceptez.",
+    sections: [
+      {
+        heading: "Utiliser Meffin",
+        paragraphs: [
+          "Meffin est une application de budget personnel. Nous vous accordons un droit d'utilisation personnel et non transférable. Ne l'utilisez pas à mauvais escient, n'essayez pas de la casser et ne l'utilisez pas pour enfreindre la loi.",
+        ],
+      },
+      {
+        heading: "Votre compte",
+        bullets: [
+          "Vous êtes responsable de votre compte et de la sécurité de vos identifiants.",
+          "Fournissez des informations exactes lors de votre inscription.",
+          "Vous devez avoir au moins 13 ans pour utiliser Meffin.",
+        ],
+      },
+      {
+        heading: "Vos données vous appartiennent",
+        paragraphs: [
+          "Vous êtes propriétaire des données de budget que vous saisissez dans Meffin. Vous pouvez les exporter ou les supprimer à tout moment. Nous les utilisons uniquement pour fournir le service, comme décrit dans la Politique de confidentialité.",
+        ],
+      },
+      {
+        heading: "Disponibilité",
+        paragraphs: [
+          "Nous faisons de notre mieux pour que Meffin fonctionne, mais nous ne pouvons pas garantir une disponibilité permanente ni l'absence d'erreurs. Nous pouvons modifier ou interrompre des fonctionnalités.",
+        ],
+      },
+      {
+        heading: "En l'état",
+        paragraphs: [
+          "Meffin est fourni « en l'état », sans garantie d'aucune sorte. C'est un outil de budget, pas un conseil financier.",
+        ],
+      },
+      {
+        heading: "Limitation de responsabilité",
+        paragraphs: [
+          "Dans les limites permises par la loi, nous ne sommes pas responsables des dommages indirects ou accessoires résultant de votre utilisation de Meffin.",
+        ],
+      },
+      {
+        heading: "Fin d'utilisation",
+        paragraphs: [
+          "Vous pouvez cesser d'utiliser Meffin et supprimer votre compte à tout moment. Nous pouvons suspendre les comptes qui enfreignent ces conditions.",
+        ],
+      },
+      {
+        heading: "Modifications",
+        paragraphs: [
+          "Nous pouvons mettre à jour ces conditions. Nous modifierons la date ci-dessus et signalerons les changements importants dans l'application. Continuer à utiliser Meffin vaut acceptation de la mise à jour.",
+        ],
+      },
+      {
+        heading: "Droit applicable",
+        paragraphs: ["Ces conditions sont régies par le droit français."],
+      },
+      {
+        heading: "Contact",
+        paragraphs: ["Des questions ? Écrivez à support@meffin.app."],
+      },
+    ],
+  },
+};
+
+export default async function TermsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const c = content[locale === "fr" ? "fr" : "en"];
+  return (
+    <LegalShell
+      locale={locale}
+      title={c.title}
+      updated={c.updated}
+      intro={c.intro}
+      sections={c.sections}
+      backLabel={c.backLabel}
+    />
+  );
+}

--- a/components/legal/legal-shell.tsx
+++ b/components/legal/legal-shell.tsx
@@ -1,0 +1,69 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export type LegalSection = {
+  heading: string;
+  paragraphs?: string[];
+  bullets?: string[];
+};
+
+export function LegalShell({
+  locale,
+  title,
+  updated,
+  intro,
+  sections,
+  backLabel,
+}: {
+  locale: string;
+  title: string;
+  updated: string;
+  intro: string;
+  sections: LegalSection[];
+  backLabel: string;
+}) {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-2xl px-5 py-12 sm:py-16">
+        <Link
+          href={`/${locale}`}
+          className="inline-flex items-center gap-2 transition-opacity hover:opacity-80"
+        >
+          <Image src="/logo.png" alt="" width={28} height={28} />
+          <span className="font-display text-base">Meffin</span>
+        </Link>
+
+        <h1 className="mt-8 font-display text-3xl sm:text-4xl">{title}</h1>
+        <p className="mt-2 text-sm text-muted-foreground">{updated}</p>
+
+        <div className="mt-8 space-y-8 text-[15px] leading-relaxed text-foreground/90">
+          <p>{intro}</p>
+          {sections.map((section, i) => (
+            <section key={i} className="space-y-3">
+              <h2 className="font-display text-xl text-foreground">{section.heading}</h2>
+              {section.paragraphs?.map((p, j) => (
+                <p key={j}>{p}</p>
+              ))}
+              {section.bullets && (
+                <ul className="list-disc space-y-1.5 pl-5 marker:text-primary">
+                  {section.bullets.map((b, j) => (
+                    <li key={j}>{b}</li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          ))}
+        </div>
+
+        <div className="mt-12 border-t border-border pt-6">
+          <Link
+            href={`/${locale}`}
+            className="text-sm text-primary transition-opacity hover:opacity-80"
+          >
+            {backLabel}
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Adds public Privacy Policy and Terms of Service pages, needed for the App Store submission and linked from the mobile app's new About section.

## What's here
- `/[locale]/privacy` and `/[locale]/terms` — public routes (not in `PROTECTED_SEGMENTS`, so no auth wall)
- Bilingual (EN/FR) from the `locale` param, matching the app's next-international setup
- Shared `LegalShell` component, styled with the existing theme tokens and Fredoka/Nunito fonts
- Content tailored to Meffin: budget data, Google/Apple sign-in, partner sharing, account deletion, export

## Needs your confirmation before shipping
- **Contact email** is `support@meffin.app` — set up that mailbox or change it (App Review may email it)
- **Governing law** says France — confirm the right jurisdiction
- Give the copy a read; it's honest to what the app does but not lawyer-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)