### PR TITLE
Add localized support and refine header controls

### DIFF
--- a/app/[locale]/(auth)/layout.tsx
+++ b/app/[locale]/(auth)/layout.tsx
@@ -13,8 +13,8 @@ export default async function AuthLayout({
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }) {
-  // Await params to fix Next.js warning
-  await params;
+  const { locale: requestedLocale } = await params;
+  const locale = requestedLocale === 'fr' ? 'fr' : 'en';
   const t = await getI18n();
 
   return (
@@ -51,22 +51,36 @@ export default async function AuthLayout({
       </div>
 
       {/* Right Side - Auth Form */}
-      <div className="flex-1 flex items-center justify-center px-4 py-8 lg:px-16 lg:py-12">
-        <div className="w-full max-w-sm mx-auto">
-          {/* Mobile Logo - Only visible on smaller screens */}
-          <div className="lg:hidden flex flex-col items-center space-y-4 mb-8">
-            <Mascot size={56} />
-            <div className="text-center space-y-1">
-              <h1 className="text-xl font-semibold">{t('app_name')}</h1>
-              <p className="text-sm text-muted-foreground">{t('app_tagline')}</p>
+      <div className="flex min-h-screen flex-1 flex-col lg:min-h-0">
+        <div className="flex flex-1 items-center justify-center px-4 py-20 lg:px-16 lg:py-12">
+          <div className="w-full max-w-sm mx-auto">
+            {/* Mobile Logo - Only visible on smaller screens */}
+            <div className="lg:hidden flex flex-col items-center space-y-4 mb-8">
+              <Mascot size={56} />
+              <div className="text-center space-y-1">
+                <h1 className="text-xl font-semibold">{t('app_name')}</h1>
+                <p className="text-sm text-muted-foreground">{t('app_tagline')}</p>
+              </div>
+            </div>
+
+            {/* Auth Form */}
+            <div className="space-y-6">
+              {children}
             </div>
           </div>
-
-          {/* Auth Form */}
-          <div className="space-y-6">
-            {children}
-          </div>
         </div>
+
+        <footer className="flex items-center justify-center gap-5 px-4 pb-6 text-xs text-muted-foreground">
+          <Link href={`/${locale}/support`} className="transition-colors hover:text-foreground">
+            {t('legal_support')}
+          </Link>
+          <Link href={`/${locale}/terms`} className="transition-colors hover:text-foreground">
+            {t('legal_terms')}
+          </Link>
+          <Link href={`/${locale}/privacy`} className="transition-colors hover:text-foreground">
+            {t('legal_privacy')}
+          </Link>
+        </footer>
       </div>
     </div>
   );

--- a/app/[locale]/(dashboard)/profile/page.tsx
+++ b/app/[locale]/(dashboard)/profile/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { HugeiconsIcon, type IconSvgElement } from '@hugeicons/react';
-import { Alert01Icon, AnalyticsUpIcon, ArrowRight01Icon, Coins01Icon, Delete02Icon, FloppyDiskIcon, LanguageCircleIcon, MoonIcon, Tag01Icon } from "@hugeicons/core-free-icons";
+import { Alert01Icon, AnalyticsUpIcon, ArrowRight01Icon, Coins01Icon, CustomerSupportIcon, Delete02Icon, FloppyDiskIcon, LanguageCircleIcon, Legal01Icon, MoonIcon, SecurityCheckIcon, Tag01Icon } from "@hugeicons/core-free-icons";
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
@@ -339,6 +339,32 @@ export default function ProfilePage() {
         <Panel>
           <SettingsRow icon={Tag01Icon} tint="green" title={t('nav_categories')} href={`/${locale}/categories`} />
           <SettingsRow icon={AnalyticsUpIcon} tint="blue" title={t('nav_trends')} href={`/${locale}/trends`} />
+        </Panel>
+      </section>
+
+      {/* Help and legal */}
+      <section className="space-y-3">
+        <SectionLabel>{t('profile_section_help')}</SectionLabel>
+        <Panel>
+          <SettingsRow
+            icon={CustomerSupportIcon}
+            tint="coral"
+            title={t('legal_support')}
+            subtitle={t('profile_support_description')}
+            href={`/${locale}/support`}
+          />
+          <SettingsRow
+            icon={SecurityCheckIcon}
+            tint="green"
+            title={t('legal_privacy')}
+            href={`/${locale}/privacy`}
+          />
+          <SettingsRow
+            icon={Legal01Icon}
+            tint="blue"
+            title={t('legal_terms')}
+            href={`/${locale}/terms`}
+          />
         </Panel>
       </section>
 

--- a/app/[locale]/privacy/page.tsx
+++ b/app/[locale]/privacy/page.tsx
@@ -82,7 +82,7 @@ const content: Record<"en" | "fr", Content> = {
       {
         heading: "Contact",
         paragraphs: [
-          "Questions or requests about your data? Email us at support@meffin.app.",
+          "Questions or requests about your data? Email us at lnevespereira@proton.me.",
         ],
       },
     ],
@@ -154,7 +154,7 @@ const content: Record<"en" | "fr", Content> = {
       {
         heading: "Contact",
         paragraphs: [
-          "Des questions ou des demandes concernant vos données ? Écrivez-nous à support@meffin.app.",
+          "Des questions ou des demandes concernant vos données ? Écrivez-nous à lnevespereira@proton.me.",
         ],
       },
     ],

--- a/app/[locale]/support/page.tsx
+++ b/app/[locale]/support/page.tsx
@@ -1,0 +1,123 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { LegalShell, type LegalSection } from "@/components/legal/legal-shell";
+
+const SUPPORT_EMAIL = "lnevespereira@proton.me";
+
+export const metadata: Metadata = {
+  title: "Meffin Support",
+  description: "Get help with Meffin and contact its developer.",
+};
+
+const content = {
+  en: {
+    title: "Meffin Support",
+    intro: "Need help with Meffin? Start with the guidance below or contact us directly.",
+    contactHeading: "Contact",
+    contactLead: "For app issues, feedback, or feature requests, email",
+    contactHint:
+      "When reporting a problem, include your device, operating system, Meffin version, and the steps that led to it. Screenshots are helpful when available.",
+    troubleshootingHeading: "Troubleshooting",
+    troubleshooting: [
+      "Make sure you are using the latest available version of Meffin.",
+      "If you cannot sign in, use the same sign-in method you used when creating your account.",
+      "Try closing and reopening the app before contacting support.",
+    ],
+    accountHeading: "Account and data",
+    accountText:
+      "For help accessing your account or questions about your personal data, contact us from the email address associated with your account whenever possible.",
+    linksHeading: "Policies",
+    privacy: "Privacy Policy",
+    terms: "Terms of Use",
+    backLabel: "← Back to Meffin",
+  },
+  fr: {
+    title: "Assistance Meffin",
+    intro:
+      "Besoin d'aide avec Meffin ? Consultez les conseils ci-dessous ou contactez-nous directement.",
+    contactHeading: "Contact",
+    contactLead:
+      "Pour un problème, un commentaire ou une suggestion de fonctionnalité, écrivez à",
+    contactHint:
+      "Lorsque vous signalez un problème, indiquez votre appareil, votre système d'exploitation, la version de Meffin et les étapes qui ont mené au problème. Une capture d'écran peut également nous aider.",
+    troubleshootingHeading: "Dépannage",
+    troubleshooting: [
+      "Vérifiez que vous utilisez la dernière version disponible de Meffin.",
+      "Si vous ne pouvez pas vous connecter, utilisez la même méthode de connexion que lors de la création de votre compte.",
+      "Essayez de fermer puis de rouvrir l'application avant de contacter l'assistance.",
+    ],
+    accountHeading: "Compte et données",
+    accountText:
+      "Pour obtenir de l'aide avec votre compte ou poser une question sur vos données personnelles, contactez-nous si possible depuis l'adresse email associée à votre compte.",
+    linksHeading: "Politiques",
+    privacy: "Politique de confidentialité",
+    terms: "Conditions d'utilisation",
+    backLabel: "← Retour à Meffin",
+  },
+} as const;
+
+export default async function SupportPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale: requestedLocale } = await params;
+  const locale = requestedLocale === "fr" ? "fr" : "en";
+  const c = content[locale];
+
+  const sections: LegalSection[] = [
+    {
+      heading: c.contactHeading,
+      paragraphs: [
+        <>
+          {c.contactLead}{" "}
+          <a
+            href={`mailto:${SUPPORT_EMAIL}`}
+            className="font-medium text-primary underline-offset-4 hover:underline"
+          >
+            {SUPPORT_EMAIL}
+          </a>
+          .
+        </>,
+        c.contactHint,
+      ],
+    },
+    {
+      heading: c.troubleshootingHeading,
+      bullets: [...c.troubleshooting],
+    },
+    {
+      heading: c.accountHeading,
+      paragraphs: [c.accountText],
+    },
+    {
+      heading: c.linksHeading,
+      paragraphs: [
+        <span className="flex flex-wrap gap-x-5 gap-y-2" key="policy-links">
+          <Link
+            href={`/${locale}/privacy`}
+            className="font-medium text-primary underline-offset-4 hover:underline"
+          >
+            {c.privacy}
+          </Link>
+          <Link
+            href={`/${locale}/terms`}
+            className="font-medium text-primary underline-offset-4 hover:underline"
+          >
+            {c.terms}
+          </Link>
+        </span>,
+      ],
+    },
+  ];
+
+  return (
+    <LegalShell
+      locale={locale}
+      title={c.title}
+      intro={c.intro}
+      sections={sections}
+      backLabel={c.backLabel}
+    />
+  );
+}

--- a/app/[locale]/terms/page.tsx
+++ b/app/[locale]/terms/page.tsx
@@ -78,7 +78,7 @@ const content: Record<"en" | "fr", Content> = {
       },
       {
         heading: "Contact",
-        paragraphs: ["Questions? Email support@meffin.app."],
+        paragraphs: ["Questions? Email lnevespereira@proton.me."],
       },
     ],
   },
@@ -145,7 +145,7 @@ const content: Record<"en" | "fr", Content> = {
       },
       {
         heading: "Contact",
-        paragraphs: ["Des questions ? Écrivez à support@meffin.app."],
+        paragraphs: ["Des questions ? Écrivez à lnevespereira@proton.me."],
       },
     ],
   },

--- a/components/dashboard/DashboardHeader.tsx
+++ b/components/dashboard/DashboardHeader.tsx
@@ -5,6 +5,7 @@ import { Calendar01Icon } from "@hugeicons/core-free-icons";
 import React from 'react';
 import { usePathname } from 'next/navigation';
 import { useCurrentLocale, useI18n } from '@/locales/client';
+import { useMonthCursor } from '@/hooks/useMonthCursor';
 import { LocaleSwitcher } from '@/components/shared/LocaleSwitcher';
 import { ThemeSwitcher } from '@/components/shared/ThemeSwitcher';
 import {
@@ -23,6 +24,8 @@ export function DashboardHeader() {
   const t = useI18n();
   const currentLocale = useCurrentLocale();
   const locale = currentLocale === 'fr' ? 'fr' : 'en';
+  const { setCursor, isCurrent } = useMonthCursor();
+  const now = new Date();
 
   const getBreadcrumbs = () => {
     const segments = pathname.split('/').filter(Boolean);
@@ -107,12 +110,19 @@ export function DashboardHeader() {
       </div>
 
       <div className="flex items-center gap-3 px-6">
-        <div className="hidden select-none items-center gap-2 text-muted-foreground md:flex">
-          <HugeiconsIcon icon={Calendar01Icon} className="h-3.5 w-3.5 text-muted-foreground" />
+        <button
+          type="button"
+          disabled={isCurrent}
+          onClick={() => setCursor(now.getMonth(), now.getFullYear())}
+          aria-label={t('month_back_to_current')}
+          title={isCurrent ? undefined : t('month_back_to_current')}
+          className="hidden h-8 items-center gap-2 rounded-md px-2 text-muted-foreground transition-colors enabled:cursor-pointer enabled:bg-primary/10 enabled:text-primary enabled:hover:bg-primary/15 md:flex disabled:cursor-default"
+        >
+          <HugeiconsIcon icon={Calendar01Icon} className="h-3.5 w-3.5" />
           <span className="text-xs font-medium">
-            {new Intl.DateTimeFormat(locale, { month: 'short', year: 'numeric' }).format(new Date())}
+            {new Intl.DateTimeFormat(locale, { month: 'short', year: 'numeric' }).format(now)}
           </span>
-        </div>
+        </button>
         <Separator orientation="vertical" className="h-6" />
         <ThemeSwitcher />
         <LocaleSwitcher showText />

--- a/components/legal/legal-shell.tsx
+++ b/components/legal/legal-shell.tsx
@@ -1,10 +1,13 @@
 import Image from "next/image";
 import Link from "next/link";
+import type { ReactNode } from "react";
+import { LocaleSwitcher } from "@/components/shared/LocaleSwitcher";
+import { ThemeSwitcher } from "@/components/shared/ThemeSwitcher";
 
 export type LegalSection = {
   heading: string;
-  paragraphs?: string[];
-  bullets?: string[];
+  paragraphs?: ReactNode[];
+  bullets?: ReactNode[];
 };
 
 export function LegalShell({
@@ -17,24 +20,30 @@ export function LegalShell({
 }: {
   locale: string;
   title: string;
-  updated: string;
-  intro: string;
+  updated?: string;
+  intro: ReactNode;
   sections: LegalSection[];
   backLabel: string;
 }) {
   return (
     <main className="min-h-screen bg-background text-foreground">
       <div className="mx-auto max-w-2xl px-5 py-12 sm:py-16">
-        <Link
-          href={`/${locale}`}
-          className="inline-flex items-center gap-2 transition-opacity hover:opacity-80"
-        >
-          <Image src="/logo.png" alt="" width={28} height={28} />
-          <span className="font-display text-base">Meffin</span>
-        </Link>
+        <div className="flex items-center justify-between gap-4">
+          <Link
+            href={`/${locale}`}
+            className="inline-flex items-center gap-2 transition-opacity hover:opacity-80"
+          >
+            <Image src="/logo.png" alt="" width={28} height={28} />
+            <span className="font-display text-base">Meffin</span>
+          </Link>
+          <div className="flex items-center gap-1">
+            <ThemeSwitcher />
+            <LocaleSwitcher showText />
+          </div>
+        </div>
 
         <h1 className="mt-8 font-display text-3xl sm:text-4xl">{title}</h1>
-        <p className="mt-2 text-sm text-muted-foreground">{updated}</p>
+        {updated && <p className="mt-2 text-sm text-muted-foreground">{updated}</p>}
 
         <div className="mt-8 space-y-8 text-[15px] leading-relaxed text-foreground/90">
           <p>{intro}</p>

--- a/components/shared/LocaleSwitcher.tsx
+++ b/components/shared/LocaleSwitcher.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { HugeiconsIcon } from "@hugeicons/react";
-import { LanguageCircleIcon } from "@hugeicons/core-free-icons";
 import { useCurrentLocale, useChangeLocale } from '@/locales/client';
 import { Button } from '@/components/ui/button';
 import {
@@ -47,6 +45,7 @@ export function LocaleSwitcher({
         <Button
           variant={variant}
           size={size}
+          aria-label={currentLocaleData?.name}
           className={`h-10 px-3 touch-manipulation active:scale-95 transition-transform ${className}`}
         >
           <div className="flex items-center gap-2">
@@ -56,7 +55,6 @@ export function LocaleSwitcher({
                 {currentLocaleData?.name}
               </span>
             )}
-            <HugeiconsIcon icon={LanguageCircleIcon} className="h-4 w-4" />
           </div>
         </Button>
       </DropdownMenuTrigger>

--- a/components/shared/ThemeSwitcher.tsx
+++ b/components/shared/ThemeSwitcher.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { HugeiconsIcon } from "@hugeicons/react";
-import { MoonIcon, Sun01Icon } from "@hugeicons/core-free-icons";
+import { Moon02Icon, Sun01Icon } from "@hugeicons/core-free-icons";
 import * as React from "react"
 import { Button } from "@/components/ui/button"
 import { useTheme } from "@/components/theme-provider"
@@ -30,7 +30,7 @@ export function ThemeSwitcher() {
       onClick={() => setTheme(theme === "light" ? "dark" : "light")}
       className="w-9 h-9"
     >
-      <HugeiconsIcon icon={MoonIcon} className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <HugeiconsIcon icon={Moon02Icon} className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
       <HugeiconsIcon icon={Sun01Icon} className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
       <span className="sr-only">Toggle theme</span>
     </Button>

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -64,6 +64,11 @@ export default {
   common_error: "Error",
   common_success: "Success",
 
+  // Legal
+  legal_support: "Support",
+  legal_terms: "Terms",
+  legal_privacy: "Privacy",
+
   // Language
   language: "Language",
   language_en: "English",
@@ -182,7 +187,9 @@ export default {
   profile_edit: "Edit",
   profile_section_budget: "Budget",
   profile_section_preferences: "Preferences",
+  profile_section_help: "Help & legal",
   profile_appearance: "Appearance",
+  profile_support_description: "Get help or contact us",
   profile_name: "Name",
   profile_email: "Email",
   profile_email_readonly: "Email cannot be modified",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -65,6 +65,11 @@ export default {
   common_error: "Erreur",
   common_success: "Succès",
 
+  // Mentions légales
+  legal_support: "Assistance",
+  legal_terms: "Conditions",
+  legal_privacy: "Confidentialité",
+
   // Language
   language: "Langue",
   language_en: "English",
@@ -185,7 +190,9 @@ export default {
   profile_edit: "Modifier",
   profile_section_budget: "Budget",
   profile_section_preferences: "Préférences",
+  profile_section_help: "Aide et mentions légales",
   profile_appearance: "Apparence",
+  profile_support_description: "Obtenir de l'aide ou nous contacter",
   profile_name: "Nom complet",
   profile_email: "Email",
   profile_email_readonly: "L'email ne peut pas être modifié",


### PR DESCRIPTION
## Summary
- add localized English and French support pages with direct contact and troubleshooting guidance
- expose Support, Terms, and Privacy from authentication and profile surfaces
- replace the temporary support email across legal pages
- simplify language controls, update the Hugeicons moon glyph, and make the current-month header indicator actionable

## Validation
- `pnpm type-check`
- targeted ESLint checks
- `pnpm test` (34 tests)
- `pnpm build:local`