### PR TITLE
Fix recurring transactions returning after deletion

### DIFF
--- a/app/[locale]/(dashboard)/transactions/page.tsx
+++ b/app/[locale]/(dashboard)/transactions/page.tsx
@@ -14,7 +14,8 @@ import {
   useAnnualTransactions,
   useCreateTransaction,
   useUpdateTransaction,
-  useDeleteTransaction
+  useDeleteTransaction,
+  type TransactionDeleteRequest,
 } from '@/hooks/useTransactions';
 import { useCategories } from '@/hooks/useCategories';
 import { usePartnerInfo } from '@/hooks/usePartner';
@@ -100,8 +101,8 @@ export default function TransactionsPage() {
     return 'until' as const;
   };
 
-  const handleDeleteTransaction = (id: string) => {
-    deleteMutation.mutate(id);
+  const handleDeleteTransaction = (request: TransactionDeleteRequest) => {
+    deleteMutation.mutate(request);
   };
 
   const closeEditForm = () => {

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { transactions, categories, users, listItems } from '@/lib/db/schema';
 import { auth } from '@/lib/auth';
-import { eq, and, inArray, isNotNull } from 'drizzle-orm';
+import { eq, and, gte, inArray, isNotNull } from 'drizzle-orm';
 import { z } from 'zod';
 import { DEFAULT_CATEGORIES } from '@/lib/default-categories';
 import { isProjectedId } from '@/lib/services/budget/project';
@@ -32,6 +32,7 @@ const updateTransactionSchema = z.object({
 /** Future months have no stored row, so they carry a synthetic id. They're preview-only:
  *  changing the forecast means editing the current month, which is a real row. */
 const PROJECTED_MESSAGE = 'This month is a forecast. Edit the current month to change it.';
+const deleteScopeSchema = z.enum(['occurrence', 'future']);
 
 export async function PUT(
   request: NextRequest,
@@ -225,6 +226,20 @@ export async function DELETE(
       return NextResponse.json({ error: PROJECTED_MESSAGE }, { status: 400 });
     }
 
+    const submittedScope = request.nextUrl.searchParams.get('scope');
+    const parsedScope = submittedScope
+      ? deleteScopeSchema.safeParse(submittedScope)
+      : null;
+
+    if (parsedScope && !parsedScope.success) {
+      return NextResponse.json({ error: 'Invalid delete scope' }, { status: 400 });
+    }
+
+    // Existing clients don't send a scope. For a recurring transaction, stopping the
+    // schedule is the least surprising behavior: a transaction the user deleted must not
+    // silently return in next month's forecast.
+    const deleteScope = parsedScope?.data ?? 'future';
+
     // Get current user's partner info to determine access
     const [user] = await db
       .select({
@@ -246,6 +261,8 @@ export async function DELETE(
       id: transactions.id,
       createdBy: transactions.createdBy,
       seriesId: transactions.seriesId,
+      monthKey: transactions.monthKey,
+      date: transactions.date,
     })
       .from(transactions)
       .where(and(
@@ -267,11 +284,51 @@ export async function DELETE(
     }
 
     if (existing.seriesId) {
-      // Void rather than delete. A removed row would just be written again by the next
-      // materialization pass, and the tombstone is what keeps the deletion sticky.
-      await db.update(transactions)
-        .set({ voided: true, updatedAt: new Date().toISOString() })
-        .where(and(eq(transactions.id, id), eq(transactions.createdBy, session.user.id)));
+      const seriesId = existing.seriesId;
+
+      if (deleteScope === 'occurrence') {
+        // Void rather than delete. A removed row would just be written again by the next
+        // materialization pass, and the tombstone is what keeps this one-month gap sticky.
+        await db.update(transactions)
+          .set({ voided: true, updatedAt: new Date().toISOString() })
+          .where(and(
+            eq(transactions.id, id),
+            eq(transactions.createdBy, session.user.id)
+          ));
+      } else {
+        const endMonth = existing.monthKey - 1;
+        const endDate = occurrenceDate(endMonth, dayOfMonth(existing.date));
+        const updatedAt = new Date().toISOString();
+
+        await db.transaction(async (tx) => {
+          // The schedule belongs to the series, not to one occurrence. Persist the bound
+          // on every row so whichever historical row becomes the live head carries the
+          // same end date and cannot restart the forecast.
+          await tx.update(transactions)
+            .set({
+              isFixed: true,
+              repeatType: 'until',
+              endDate,
+              endMonth,
+              updatedAt,
+            })
+            .where(and(
+              eq(transactions.seriesId, seriesId),
+              eq(transactions.createdBy, session.user.id)
+            ));
+
+          // Keep historical occurrences, but remove the selected month and any stored
+          // rows after it. Future projections disappear because the head now ends in the
+          // preceding month.
+          await tx.update(transactions)
+            .set({ voided: true, updatedAt })
+            .where(and(
+              eq(transactions.seriesId, seriesId),
+              eq(transactions.createdBy, session.user.id),
+              gte(transactions.monthKey, existing.monthKey)
+            ));
+        });
+      }
     } else {
       const result = await db.delete(transactions)
         .where(and(
@@ -285,7 +342,7 @@ export async function DELETE(
       }
     }
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, scope: deleteScope });
   } catch (error) {
     console.error('Error deleting transaction:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/components/transactions/AnnualTransactionList.tsx
+++ b/components/transactions/AnnualTransactionList.tsx
@@ -4,25 +4,17 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { Calendar01Icon, Delete02Icon, Edit01Icon } from "@hugeicons/core-free-icons";
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { TransactionWithCategory } from '@/types';
 import { useI18n, useCurrentLocale } from '@/locales/client';
 import { getCategoryDisplayName } from '@/lib/category-utils';
 import { useFormatCurrency } from '@/lib/currency-utils';
+import type { TransactionDeleteRequest } from '@/hooks/useTransactions';
+import { TransactionDeleteDialog } from './TransactionDeleteDialog';
 
 interface AnnualTransactionListProps {
   transactions: TransactionWithCategory[];
   onEdit: (transaction: TransactionWithCategory) => void;
-  onDelete: (id: string) => void;
+  onDelete: (request: TransactionDeleteRequest) => void;
   isDeleting?: boolean;
   hasPartner?: boolean;
   currentUserId?: string;
@@ -37,7 +29,8 @@ export function AnnualTransactionList({
   currentUserId,
 }: AnnualTransactionListProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [transactionToDelete, setTransactionToDelete] = useState<string | null>(null);
+  const [transactionToDelete, setTransactionToDelete] =
+    useState<TransactionWithCategory | null>(null);
   const t = useI18n();
   const currentLocale = useCurrentLocale();
   const formatCurrency = useFormatCurrency();
@@ -62,15 +55,14 @@ export function AnnualTransactionList({
     return date.toLocaleDateString(currentLocale === 'fr' ? 'fr-FR' : 'en-US', { month: 'long' });
   };
 
-  const handleDeleteClick = (id: string) => {
-    setTransactionToDelete(id);
+  const handleDeleteClick = (transaction: TransactionWithCategory) => {
+    setTransactionToDelete(transaction);
     setDeleteDialogOpen(true);
   };
 
-  const handleConfirmDelete = () => {
-    if (transactionToDelete) {
-      onDelete(transactionToDelete);
-      setDeleteDialogOpen(false);
+  const handleDeleteDialogChange = (open: boolean) => {
+    setDeleteDialogOpen(open);
+    if (!open) {
       setTransactionToDelete(null);
     }
   };
@@ -166,7 +158,7 @@ export function AnnualTransactionList({
                         <Button
                           size="sm"
                           variant="ghost"
-                          onClick={() => handleDeleteClick(transaction.id)}
+                          onClick={() => handleDeleteClick(transaction)}
                           disabled={isDeleting}
                           className="h-7 w-7 md:h-8 md:w-8 p-0 hover:bg-destructive/10 hover:text-destructive cursor-pointer"
                         >
@@ -182,26 +174,13 @@ export function AnnualTransactionList({
         </div>
       </div>
 
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('transaction_delete_title') || 'Delete Transaction'}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('transaction_delete_confirmation') || 'Are you sure you want to delete this transaction? This action cannot be undone.'}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel className="cursor-pointer">{t('common_cancel') || 'Cancel'}</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleConfirmDelete}
-              disabled={isDeleting}
-              className="bg-destructive hover:bg-destructive/90 cursor-pointer disabled:cursor-not-allowed"
-            >
-              {isDeleting ? (t('transaction_deleting') || 'Deleting...') : (t('common_delete') || 'Delete')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <TransactionDeleteDialog
+        transaction={transactionToDelete}
+        open={deleteDialogOpen}
+        onOpenChange={handleDeleteDialogChange}
+        onDelete={onDelete}
+        isDeleting={isDeleting}
+      />
     </>
   );
 }

--- a/components/transactions/TransactionDeleteDialog.tsx
+++ b/components/transactions/TransactionDeleteDialog.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import type {
+  TransactionDeleteRequest,
+  TransactionDeleteScope,
+} from '@/hooks/useTransactions';
+import { useI18n } from '@/locales/client';
+import type { TransactionWithCategory } from '@/types';
+
+type TransactionDeleteDialogProps = {
+  transaction: TransactionWithCategory | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDelete: (request: TransactionDeleteRequest) => void;
+  isDeleting?: boolean;
+};
+
+export function TransactionDeleteDialog({
+  transaction,
+  open,
+  onOpenChange,
+  onDelete,
+  isDeleting = false,
+}: TransactionDeleteDialogProps) {
+  const t = useI18n();
+  const isRecurring = Boolean(transaction?.seriesId);
+  const canDeleteSingleOccurrence =
+    isRecurring && transaction?.repeatType !== 'annual';
+
+  const deleteTransaction = (scope?: TransactionDeleteScope) => {
+    if (!transaction) return;
+
+    onDelete({ id: transaction.id, scope });
+    onOpenChange(false);
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {isRecurring
+              ? t('transaction_delete_recurring_title')
+              : t('transaction_delete_title')}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {isRecurring
+              ? t('transaction_delete_recurring_confirmation')
+              : t('transaction_delete_confirmation')}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel className="cursor-pointer">
+            {t('common_cancel')}
+          </AlertDialogCancel>
+
+          {canDeleteSingleOccurrence && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => deleteTransaction('occurrence')}
+              disabled={isDeleting}
+              className="cursor-pointer"
+            >
+              {t('transaction_delete_occurrence')}
+            </Button>
+          )}
+
+          <AlertDialogAction
+            onClick={() => deleteTransaction(isRecurring ? 'future' : undefined)}
+            disabled={isDeleting}
+            className="cursor-pointer bg-destructive hover:bg-destructive/90 disabled:cursor-not-allowed"
+          >
+            {isDeleting
+              ? t('transaction_deleting')
+              : isRecurring
+                ? t('transaction_delete_future')
+                : t('common_delete')}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/components/transactions/TransactionList.tsx
+++ b/components/transactions/TransactionList.tsx
@@ -6,27 +6,19 @@ import { useState } from 'react';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { Button } from '@/components/ui/button';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { TransactionWithCategory } from '@/types';
 import { useI18n } from '@/locales/client';
+import type { TransactionDeleteRequest } from '@/hooks/useTransactions';
 
 import { getCategoryDisplayName } from '@/lib/category-utils';
 import { useFormatCurrency } from '@/lib/currency-utils';
+import { TransactionDeleteDialog } from './TransactionDeleteDialog';
 
 interface TransactionListProps {
   transactions: TransactionWithCategory[];
   type: 'income' | 'expense';
   onEdit: (transaction: TransactionWithCategory) => void;
-  onDelete: (id: string) => void;
+  onDelete: (request: TransactionDeleteRequest) => void;
   isDeleting?: boolean;
   hasPartner?: boolean;
   currentUserId?: string;
@@ -48,7 +40,8 @@ export function TransactionList({
   monthLabel,
 }: TransactionListProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [transactionToDelete, setTransactionToDelete] = useState<string | null>(null);
+  const [transactionToDelete, setTransactionToDelete] =
+    useState<TransactionWithCategory | null>(null);
   const t = useI18n();
 
   const formatCurrency = useFormatCurrency();
@@ -94,15 +87,14 @@ export function TransactionList({
     transaction => transaction.category.type === type
   );
 
-  const handleDeleteClick = (id: string) => {
-    setTransactionToDelete(id);
+  const handleDeleteClick = (transaction: TransactionWithCategory) => {
+    setTransactionToDelete(transaction);
     setDeleteDialogOpen(true);
   };
 
-  const handleConfirmDelete = () => {
-    if (transactionToDelete) {
-      onDelete(transactionToDelete);
-      setDeleteDialogOpen(false);
+  const handleDeleteDialogChange = (open: boolean) => {
+    setDeleteDialogOpen(open);
+    if (!open) {
       setTransactionToDelete(null);
     }
   };
@@ -265,7 +257,7 @@ export function TransactionList({
                       <Button
                         size="sm"
                         variant="ghost"
-                        onClick={() => handleDeleteClick(transaction.id)}
+                        onClick={() => handleDeleteClick(transaction)}
                         disabled={isDeleting}
                         className="h-7 w-7 md:h-8 md:w-8 p-0 hover:bg-destructive/10 hover:text-destructive cursor-pointer"
                       >
@@ -280,26 +272,13 @@ export function TransactionList({
         </div>
       </div>
 
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('transaction_delete_title') || 'Delete Transaction'}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('transaction_delete_confirmation') || 'Are you sure you want to delete this transaction? This action cannot be undone.'}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel className="cursor-pointer">{t('common_cancel') || 'Cancel'}</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleConfirmDelete}
-              disabled={isDeleting}
-              className="bg-destructive hover:bg-destructive/90 cursor-pointer disabled:cursor-not-allowed"
-            >
-              {isDeleting ? (t('transaction_deleting') || 'Deleting...') : (t('common_delete') || 'Delete')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <TransactionDeleteDialog
+        transaction={transactionToDelete}
+        open={deleteDialogOpen}
+        onOpenChange={handleDeleteDialogChange}
+        onDelete={onDelete}
+        isDeleting={isDeleting}
+      />
     </>
   );
 }

--- a/hooks/useTransactions.ts
+++ b/hooks/useTransactions.ts
@@ -113,8 +113,19 @@ async function updateTransaction(id: string, data: TransactionFormData): Promise
   return response.json();
 }
 
-async function deleteTransaction(id: string): Promise<{ success: boolean }> {
-  const response = await fetch(`/api/transactions/${id}`, {
+export type TransactionDeleteScope = 'occurrence' | 'future';
+
+export type TransactionDeleteRequest = {
+  id: string;
+  scope?: TransactionDeleteScope;
+};
+
+async function deleteTransaction({
+  id,
+  scope,
+}: TransactionDeleteRequest): Promise<{ success: boolean }> {
+  const query = scope ? `?scope=${scope}` : '';
+  const response = await fetch(`/api/transactions/${id}${query}`, {
     method: 'DELETE',
     credentials: 'include',
   });

--- a/lib/services/budget/project.test.ts
+++ b/lib/services/budget/project.test.ts
@@ -191,6 +191,27 @@ describe('projectSeries — monthly', () => {
     expect(entries.map(e => e.monthKey)).toEqual([JUL_2026 + 1, JUL_2026 + 2]);
   });
 
+  it('does not resume a stopped series after its final occurrence was voided', () => {
+    // Regression: deleting July used to void only July. The live March row then became
+    // the template again and recreated the salary in every forecast from August onward.
+    const stopped = head({
+      monthKey: JUL_2026 - 4,
+      lastOccupied: JUL_2026,
+      endMonth: JUL_2026 - 1,
+      repeatType: 'until',
+      endDate: '2026-06-05 12:00:00',
+    });
+
+    const entries = projectSeries(
+      [stopped],
+      JUL_2026 + 1,
+      JUL_2026 + 6,
+      occupy(JUL_2026 - 4, JUL_2026)
+    );
+
+    expect(entries).toEqual([]);
+  });
+
   it('clamps the day when projecting into a short month', () => {
     const endOfMonth = head({ monthKey: monthKey(2026, 0), date: '2026-01-31T12:00:00.000Z' });
     const entries = projectSeries([endOfMonth], monthKey(2026, 1), monthKey(2026, 1), new Set());

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -308,6 +308,11 @@ export default {
   transaction_delete_title: "Delete Transaction",
   transaction_delete_confirmation:
     "Are you sure you want to delete this transaction? This action cannot be undone.",
+  transaction_delete_recurring_title: "Delete recurring transaction",
+  transaction_delete_recurring_confirmation:
+    "Choose whether to remove only this occurrence or stop the transaction from here onward.",
+  transaction_delete_occurrence: "Only this occurrence",
+  transaction_delete_future: "This and future occurrences",
   transaction_deleting: "Deleting...",
   transaction_recurring_monthly: "Monthly",
   transaction_recurring_ended: "Ended",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -312,6 +312,11 @@ export default {
   transaction_delete_title: "Supprimer la transaction",
   transaction_delete_confirmation:
     "Êtes-vous sûr de vouloir supprimer cette transaction ? Cette action ne peut pas être annulée.",
+  transaction_delete_recurring_title: "Supprimer la transaction récurrente",
+  transaction_delete_recurring_confirmation:
+    "Choisissez si vous souhaitez supprimer uniquement cette occurrence ou arrêter la transaction à partir d’ici.",
+  transaction_delete_occurrence: "Uniquement cette occurrence",
+  transaction_delete_future: "Celle-ci et les suivantes",
   transaction_deleting: "Suppression...",
   transaction_recurring_monthly: "Mensuel",
   transaction_recurring_ended: "Terminé",


### PR DESCRIPTION
## Summary
- stop a recurring series from the selected occurrence onward by default
- keep an explicit option to remove only one occurrence on web
- preserve past occurrences while voiding stored current and future rows transactionally
- keep existing mobile clients safe through backward-compatible API behavior
- centralize the recurring deletion dialog with English and French copy

## Root cause
Deleting a recurring occurrence only created a tombstone for that month. An older live row remained the series head, so projections resumed in the following month.

## Verification
- 42 tests passed
- TypeScript passed
- ESLint passed
- Next.js production build passed