### PR TITLE
Archive categories without losing financial history

### DIFF
--- a/app/[locale]/(dashboard)/categories/page.tsx
+++ b/app/[locale]/(dashboard)/categories/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Add01Icon, Delete02Icon, Edit01Icon, Tag01Icon } from "@hugeicons/core-free-icons";
+import { Add01Icon, ArchiveRestoreIcon, Delete02Icon, Edit01Icon, Tag01Icon } from "@hugeicons/core-free-icons";
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -22,12 +22,14 @@ import {
   useCreateCategory,
   useUpdateCategory,
   useDeleteCategory,
+  useRestoreCategory,
 } from '@/hooks/useCategories';
 import { Category, CategoryFormData, CategoryType } from '@/types';
 import { useI18n } from '@/locales/client';
 import { getCategoryDisplayName } from '@/lib/category-utils';
 import { toast } from 'sonner';
 import { PageHeader } from '@/components/shared/PageHeader';
+import { useSession } from '@/lib/auth-client';
 
 export default function CategoriesPage() {
   const t = useI18n();
@@ -36,10 +38,12 @@ export default function CategoriesPage() {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [categoryToDelete, setCategoryToDelete] = useState<Category | null>(null);
 
-  const { data: categoriesData, isLoading, error } = useCategories();
+  const { data: session } = useSession();
+  const { data: categoriesData, isLoading, error } = useCategories({ includeArchived: true });
   const createMutation = useCreateCategory();
   const updateMutation = useUpdateCategory();
   const deleteMutation = useDeleteCategory();
+  const restoreMutation = useRestoreCategory();
 
   const showMutationError = (error: Error) => {
     if (error instanceof CategoryMutationError) {
@@ -93,21 +97,34 @@ export default function CategoriesPage() {
       const categoryName = getCategoryDisplayName(categoryToDelete, t);
 
       deleteMutation.mutate(categoryToDelete.id, {
-        onSuccess: () => {
+        onSuccess: ({ archived }) => {
           setDeleteDialogOpen(false);
           setCategoryToDelete(null);
-          toast.success(t('categories_delete_success', { name: categoryName }));
+          toast.success(
+            archived
+              ? t('categories_archive_success', { name: categoryName })
+              : t('categories_delete_success', { name: categoryName })
+          );
         },
         onError: (error) => {
           const message = error instanceof Error ? error.message : '';
-          const errorMessage = message === 'Cannot delete this category because it is used by existing transactions.'
-            ? t('categories_delete_in_use_error')
-            : message || t('categories_delete_error');
-
-          toast.error(errorMessage);
+          toast.error(message || t('categories_delete_error'));
         },
       });
     }
+  };
+
+  const handleRestore = (category: Category) => {
+    const categoryName = getCategoryDisplayName(category, t);
+
+    restoreMutation.mutate(category.id, {
+      onSuccess: () => {
+        toast.success(t('categories_restore_success', { name: categoryName }));
+      },
+      onError: () => {
+        toast.error(t('categories_restore_error'));
+      },
+    });
   };
 
   const closeEditForm = () => {
@@ -131,7 +148,8 @@ export default function CategoriesPage() {
 
   const categories = categoriesData?.categories || [];
   const defaultCats = categories.filter(cat => !cat.isCustom);
-  const customCats = categories.filter(cat => cat.isCustom);
+  const customCats = categories.filter(cat => cat.isCustom && !cat.archivedAt);
+  const archivedCats = categories.filter(cat => cat.isCustom && cat.archivedAt);
 
   return (
     <div className="space-y-4 md:space-y-6">
@@ -251,31 +269,95 @@ export default function CategoriesPage() {
                     </div>
                   </div>
 
-                  <div className="flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity shrink-0">
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => handleEditCategory(category)}
-                      className="h-7 w-7 md:h-8 md:w-8 p-0 hover:bg-primary/10 hover:text-primary"
-                    >
-                      <HugeiconsIcon icon={Edit01Icon} className="h-3 w-3 md:h-3.5 md:w-3.5" />
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => handleDeleteClick(category)}
-                      disabled={deleteMutation.isPending}
-                      className="h-7 w-7 md:h-8 md:w-8 p-0 hover:bg-destructive/10 hover:text-destructive"
-                    >
-                      <HugeiconsIcon icon={Delete02Icon} className="h-3 w-3 md:h-3.5 md:w-3.5" />
-                    </Button>
-                  </div>
+                  {category.userId === session?.user.id && (
+                    <div className="flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity shrink-0">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleEditCategory(category)}
+                        className="h-7 w-7 md:h-8 md:w-8 p-0 hover:bg-primary/10 hover:text-primary"
+                      >
+                        <HugeiconsIcon icon={Edit01Icon} className="h-3 w-3 md:h-3.5 md:w-3.5" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleDeleteClick(category)}
+                        disabled={deleteMutation.isPending}
+                        className="h-7 w-7 md:h-8 md:w-8 p-0 hover:bg-destructive/10 hover:text-destructive"
+                      >
+                        <HugeiconsIcon icon={Delete02Icon} className="h-3 w-3 md:h-3.5 md:w-3.5" />
+                      </Button>
+                    </div>
+                  )}
                 </div>
               ))}
             </div>
           )}
         </div>
       </div>
+
+      {archivedCats.length > 0 && (
+        <div className="rounded-xl border border-border bg-card/60 shadow-card">
+          <div className="p-4 md:p-6">
+            <div className="mb-4 flex items-center justify-between md:mb-6">
+              <div>
+                <h2 className="text-lg font-bold tracking-tight md:text-xl">
+                  {t('categories_archived_title')}
+                </h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t('categories_archived_description')}
+                </p>
+              </div>
+              <div className="rounded-full border border-border bg-muted/50 px-2 py-1 text-xs font-medium text-muted-foreground md:px-3">
+                {archivedCats.length}
+              </div>
+            </div>
+
+            <div className="space-y-2 md:space-y-3">
+              {archivedCats.map((category) => (
+                <div
+                  key={category.id}
+                  className="flex items-center justify-between rounded-lg border border-transparent bg-muted/10 p-3 opacity-75 md:p-4"
+                >
+                  <div className="flex min-w-0 flex-1 items-center gap-3 md:gap-4">
+                    <div
+                      className="flex size-8 shrink-0 items-center justify-center rounded-lg md:size-10"
+                      style={{ backgroundColor: `${category.color}20` }}
+                    >
+                      <div
+                        className="size-2 rounded-full md:size-3"
+                        style={{ backgroundColor: category.color }}
+                      />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-semibold md:text-base">
+                        {getCategoryDisplayName(category, t)}
+                      </div>
+                      <div className="mt-0.5 text-xs text-muted-foreground md:mt-1">
+                        {category.type === 'income' ? t('categories_income') : t('categories_expense')}
+                      </div>
+                    </div>
+                  </div>
+
+                  {category.userId === session?.user.id && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => handleRestore(category)}
+                      disabled={restoreMutation.isPending}
+                      className="shrink-0"
+                    >
+                      <HugeiconsIcon icon={ArchiveRestoreIcon} className="mr-2 size-4" />
+                      {t('categories_restore')}
+                    </Button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Category Form Modals */}
       <CategoryForm
@@ -308,6 +390,9 @@ export default function CategoriesPage() {
             <AlertDialogTitle>{t('categories_delete_title')}</AlertDialogTitle>
             <AlertDialogDescription>
               {t('categories_delete_confirmation', { name: categoryToDelete?.name })}
+              <span className="mt-2 block">
+                {t('categories_delete_archive_explanation')}
+              </span>
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/app/[locale]/(dashboard)/transactions/page.tsx
+++ b/app/[locale]/(dashboard)/transactions/page.tsx
@@ -173,6 +173,10 @@ export default function TransactionsPage() {
   const allTransactions = transactionsData?.transactions ?? [];
   const allAnnualTransactions = annualTransactionsData?.transactions ?? [];
   const categories = categoriesData?.categories ?? [];
+  const editCategories =
+    editingTransaction && !categories.some(category => category.id === editingTransaction.categoryId)
+      ? [...categories, editingTransaction.category]
+      : categories;
   const exportableCount = allTransactions.filter((tx) => tx.source !== 'projected').length;
 
   // Filter transactions based on type
@@ -379,7 +383,7 @@ export default function TransactionsPage() {
           isOpen={true}
           onClose={closeEditForm}
           onSubmit={handleUpdateTransaction}
-          categories={categories}
+          categories={editCategories}
           initialData={{
             description: editingTransaction.description,
             amount: Number(editingTransaction.amount),

--- a/app/api/categories/[id]/route.ts
+++ b/app/api/categories/[id]/route.ts
@@ -1,16 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
-import { categories, transactions } from '@/lib/db/schema';
+import { categories, listItems, lists, transactions } from '@/lib/db/schema';
 import { auth } from '@/lib/auth';
 import { eq, and } from 'drizzle-orm';
 import { z } from 'zod';
 import { isDefaultCategoryId } from '@/lib/default-category-identity';
 import { findCategoryNameConflict } from '@/lib/services/categories/category-name';
+import { shouldArchiveCategory } from '@/lib/services/categories/lifecycle';
 
 const updateCategorySchema = z.object({
   name: z.string().trim().min(1, 'Name is required').max(100, 'Name too long'),
   type: z.enum(['income', 'expense']),
   color: z.string().regex(/^#[0-9A-F]{6}$/i, 'Invalid color format'),
+});
+
+const restoreCategorySchema = z.object({
+  archived: z.literal(false),
 });
 
 export async function PUT(
@@ -91,6 +96,7 @@ export async function PUT(
       isCustom: true,
       userId: updatedCategory.userId,
       createdAt: updatedCategory.createdAt,
+      archivedAt: updatedCategory.archivedAt,
     };
 
     return NextResponse.json({ category: categoryResponse });
@@ -100,6 +106,58 @@ export async function PUT(
     }
 
     console.error('Error updating category:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await auth.api.getSession({ headers: request.headers });
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+    restoreCategorySchema.parse(await request.json());
+
+    if (isDefaultCategoryId(id)) {
+      return NextResponse.json({ error: 'Cannot restore default categories' }, { status: 403 });
+    }
+
+    const [restoredCategory] = await db.update(categories)
+      .set({ archivedAt: null })
+      .where(and(
+        eq(categories.id, id),
+        eq(categories.userId, session.user.id)
+      ))
+      .returning();
+
+    if (!restoredCategory) {
+      return NextResponse.json({ error: 'Category not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      category: {
+        id: restoredCategory.id,
+        name: restoredCategory.name,
+        type: restoredCategory.type,
+        color: restoredCategory.color,
+        isCustom: true,
+        userId: restoredCategory.userId,
+        createdAt: restoredCategory.createdAt,
+        archivedAt: restoredCategory.archivedAt,
+      },
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    console.error('Error restoring category:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
@@ -135,16 +193,36 @@ export async function DELETE(
       return NextResponse.json({ error: 'Category not found' }, { status: 404 });
     }
 
-    // Check if category has transactions
-    const categoryTransactions = await db.select()
-      .from(transactions)
-      .where(eq(transactions.categoryId, id))
-      .limit(1);
+    const [categoryTransactions, categoryLists, categoryListItems] = await Promise.all([
+      db.select({ id: transactions.id })
+        .from(transactions)
+        .where(eq(transactions.categoryId, id))
+        .limit(1),
+      db.select({ id: lists.id })
+        .from(lists)
+        .where(eq(lists.categoryId, id))
+        .limit(1),
+      db.select({ id: listItems.id })
+        .from(listItems)
+        .where(eq(listItems.categoryId, id))
+        .limit(1),
+    ]);
 
-    if (categoryTransactions.length > 0) {
-      return NextResponse.json({
-        error: 'Cannot delete this category because it is used by existing transactions.'
-      }, { status: 409 });
+    const shouldArchive = shouldArchiveCategory({
+      transactions: categoryTransactions.length > 0,
+      lists: categoryLists.length > 0,
+      listItems: categoryListItems.length > 0,
+    });
+
+    if (shouldArchive) {
+      await db.update(categories)
+        .set({ archivedAt: new Date() })
+        .where(and(
+          eq(categories.id, id),
+          eq(categories.userId, session.user.id)
+        ));
+
+      return NextResponse.json({ success: true, archived: true });
     }
 
     await db.delete(categories)
@@ -154,7 +232,7 @@ export async function DELETE(
       ))
       .returning();
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, archived: false });
   } catch (error) {
     console.error('Error deleting category:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { categories, users } from '@/lib/db/schema';
 import { auth } from '@/lib/auth';
-import { eq, or } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { z } from 'zod';
 import { DEFAULT_CATEGORIES } from '@/lib/default-categories';
 import { Category } from '@/types';
@@ -37,10 +37,18 @@ export async function GET(request: NextRequest) {
 
     // Get custom categories from user and partner
     const userIds = user[0].partnerId ? [session.user.id, user[0].partnerId] : [session.user.id];
+    const includeArchived = request.nextUrl.searchParams.get('includeArchived') === 'true';
 
     const customCategories = await db.select()
       .from(categories)
-      .where(or(...userIds.map(id => eq(categories.userId, id))))
+      .where(
+        includeArchived
+          ? inArray(categories.userId, userIds)
+          : and(
+              inArray(categories.userId, userIds),
+              isNull(categories.archivedAt)
+            )
+      )
       .orderBy(categories.name);
 
     // Convert database categories to unified format
@@ -52,6 +60,7 @@ export async function GET(request: NextRequest) {
       isCustom: true,
       userId: cat.userId,
       createdAt: cat.createdAt,
+      archivedAt: cat.archivedAt,
     }));
 
     // Convert default categories to unified format
@@ -63,6 +72,7 @@ export async function GET(request: NextRequest) {
       isCustom: false,
       userId: null,
       createdAt: undefined,
+      archivedAt: null,
     }));
 
     // Combine default and custom categories
@@ -126,6 +136,7 @@ export async function POST(request: NextRequest) {
       isCustom: true,
       userId: newCategory.userId,
       createdAt: newCategory.createdAt,
+      archivedAt: newCategory.archivedAt,
     };
 
     return NextResponse.json({ category: categoryResponse });

--- a/app/api/lists/[id]/items/route.ts
+++ b/app/api/lists/[id]/items/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
-import { lists, listItems, users, categories } from '@/lib/db/schema';
+import { lists, listItems, users } from '@/lib/db/schema';
 import { auth } from '@/lib/auth';
 import { eq, and, or } from 'drizzle-orm';
 import { z } from 'zod';
-import { DEFAULT_CATEGORIES } from '@/lib/default-categories';
-import { isDefaultCategoryId } from '@/lib/default-category-identity';
+import { canUseCategory } from '@/lib/services/categories/access';
 const createItemSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   estimatedPrice: z.number().positive().optional(),
@@ -62,32 +61,12 @@ export async function POST(
       return NextResponse.json({ error: 'List not found or unauthorized' }, { status: 404 });
     }
 
-    // Validate category exists
-    const isDefaultCategory = isDefaultCategoryId(validatedData.categoryId);
+    const userIds = user[0].partnerId
+      ? [session.user.id, user[0].partnerId]
+      : [session.user.id];
 
-    if (!isDefaultCategory) {
-      const customCategory = await db.select()
-        .from(categories)
-        .where(eq(categories.id, validatedData.categoryId))
-        .limit(1);
-
-      if (customCategory.length === 0) {
-        return NextResponse.json({ error: 'Invalid category' }, { status: 400 });
-      }
-
-      // Check if user has access to the custom category
-      const categoryBelongsToUser = user[0].partnerId
-        ? (customCategory[0].userId === session.user.id || customCategory[0].userId === user[0].partnerId)
-        : customCategory[0].userId === session.user.id;
-
-      if (!categoryBelongsToUser) {
-        return NextResponse.json({ error: 'Invalid category' }, { status: 400 });
-      }
-    } else {
-      const defaultCategory = DEFAULT_CATEGORIES.find(cat => cat.id === validatedData.categoryId);
-      if (!defaultCategory) {
-        return NextResponse.json({ error: 'Invalid category' }, { status: 400 });
-      }
+    if (!await canUseCategory({ categoryId: validatedData.categoryId, userIds })) {
+      return NextResponse.json({ error: 'Invalid category' }, { status: 400 });
     }
 
     const [newItem] = await db.insert(listItems).values({

--- a/app/api/lists/[id]/route.ts
+++ b/app/api/lists/[id]/route.ts
@@ -6,6 +6,7 @@ import { eq, desc, or, and } from 'drizzle-orm';
 import { z } from 'zod';
 import { DEFAULT_CATEGORIES } from '@/lib/default-categories';
 import { Category } from '@/types';
+import { canUseCategory } from '@/lib/services/categories/access';
 
 const updateListSchema = z.object({
   title: z.string().min(1, 'Title is required'),
@@ -105,6 +106,7 @@ export async function GET(
         isCustom: false,
         userId: null,
         createdAt: undefined,
+        archivedAt: null,
       };
     });
 
@@ -118,6 +120,7 @@ export async function GET(
         isCustom: true,
         userId: cat.userId,
         createdAt: cat.createdAt,
+        archivedAt: cat.archivedAt,
       };
     });
 
@@ -133,6 +136,7 @@ export async function GET(
         isCustom: false,
         userId: null,
         createdAt: undefined,
+        archivedAt: null,
       }
     }));
 
@@ -180,6 +184,25 @@ export async function PUT(
 
     if (!existingList.length) {
       return NextResponse.json({ error: 'List not found or unauthorized' }, { status: 404 });
+    }
+
+    const [user] = await db
+      .select({ partnerId: users.partnerId })
+      .from(users)
+      .where(eq(users.id, session.user.id))
+      .limit(1);
+
+    const userIds = user?.partnerId
+      ? [session.user.id, user.partnerId]
+      : [session.user.id];
+    const keepsCurrentCategory = validatedData.categoryId === existingList[0].categoryId;
+
+    if (!await canUseCategory({
+      categoryId: validatedData.categoryId,
+      userIds,
+      includeArchived: keepsCurrentCategory,
+    })) {
+      return NextResponse.json({ error: 'Invalid category' }, { status: 400 });
     }
 
     const [updatedList] = await db.update(lists)

--- a/app/api/lists/route.ts
+++ b/app/api/lists/route.ts
@@ -4,6 +4,7 @@ import { lists, listItems, users } from '@/lib/db/schema';
 import { auth } from '@/lib/auth';
 import { eq, desc, or, and, sql } from 'drizzle-orm';
 import { z } from 'zod';
+import { canUseCategory } from '@/lib/services/categories/access';
 
 const createListSchema = z.object({
   title: z.string().min(1, 'Title is required'),
@@ -117,6 +118,20 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json();
     const validatedData = createListSchema.parse(body);
+
+    const [user] = await db
+      .select({ partnerId: users.partnerId })
+      .from(users)
+      .where(eq(users.id, session.user.id))
+      .limit(1);
+
+    const userIds = user?.partnerId
+      ? [session.user.id, user.partnerId]
+      : [session.user.id];
+
+    if (!await canUseCategory({ categoryId: validatedData.categoryId, userIds })) {
+      return NextResponse.json({ error: 'Invalid category' }, { status: 400 });
+    }
 
     const [newList] = await db.insert(lists).values({
       id: crypto.randomUUID(),

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -1,10 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
-import { transactions, categories, users, listItems } from '@/lib/db/schema';
+import { transactions, users, listItems } from '@/lib/db/schema';
 import { auth } from '@/lib/auth';
 import { eq, and, gte, inArray, isNotNull } from 'drizzle-orm';
 import { z } from 'zod';
-import { DEFAULT_CATEGORIES } from '@/lib/default-categories';
 import { isProjectedId } from '@/lib/services/budget/project';
 import {
   monthKeyFromDateString,
@@ -16,7 +15,7 @@ import {
   resolveEndMonth,
   resolveOccurrenceMonth,
 } from '@/lib/services/budget/schedule';
-import { isDefaultCategoryId } from '@/lib/default-category-identity';
+import { canUseCategory } from '@/lib/services/categories/access';
 
 const updateTransactionSchema = z.object({
   description: z.string().min(1, 'Description is required'),
@@ -90,25 +89,13 @@ export async function PUT(
       }, { status: 403 });
     }
 
-    // Validate category exists
-    const isDefaultCategory = isDefaultCategoryId(validatedData.categoryId);
-
-    if (!isDefaultCategory) {
-      // Custom category must belong to the user or their partner
-      const customCategory = await db.select()
-        .from(categories)
-        .where(eq(categories.id, validatedData.categoryId))
-        .limit(1);
-
-      if (customCategory.length === 0 || !userIds.includes(customCategory[0].userId)) {
-        return NextResponse.json({ error: 'Invalid category' }, { status: 400 });
-      }
-    } else {
-      // Check if default category exists
-      const defaultCategory = DEFAULT_CATEGORIES.find(cat => cat.id === validatedData.categoryId);
-      if (!defaultCategory) {
-        return NextResponse.json({ error: 'Invalid category' }, { status: 400 });
-      }
+    const keepsCurrentCategory = validatedData.categoryId === existing.categoryId;
+    if (!await canUseCategory({
+      categoryId: validatedData.categoryId,
+      userIds,
+      includeArchived: keepsCurrentCategory,
+    })) {
+      return NextResponse.json({ error: 'Invalid category' }, { status: 400 });
     }
 
     const submittedDate = validatedData.date.toISOString();

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -1,10 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
-import { transactions, categories, users } from '@/lib/db/schema';
+import { transactions, users } from '@/lib/db/schema';
 import { auth } from '@/lib/auth';
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
-import { DEFAULT_CATEGORIES } from '@/lib/default-categories';
 import { Category } from '@/types';
 import {
   resolveViewer,
@@ -19,7 +18,7 @@ import {
   resolveEndMonth,
   resolveOccurrenceMonth,
 } from '@/lib/services/budget/schedule';
-import { isDefaultCategoryId } from '@/lib/default-category-identity';
+import { canUseCategory } from '@/lib/services/categories/access';
 
 const createTransactionSchema = z.object({
   description: z.string().min(1, 'Description is required'),
@@ -104,32 +103,17 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const validatedData = createTransactionSchema.parse(body);
 
-    // Validate category exists
-    const isDefaultCategory = isDefaultCategoryId(validatedData.categoryId);
+    const [user] = await db.select({ partnerId: users.partnerId })
+      .from(users)
+      .where(eq(users.id, session.user.id))
+      .limit(1);
 
-    if (!isDefaultCategory) {
-      // Custom category must belong to the user or their partner
-      const [user] = await db.select({ partnerId: users.partnerId })
-        .from(users)
-        .where(eq(users.id, session.user.id))
-        .limit(1);
+    const userIds = user?.partnerId
+      ? [session.user.id, user.partnerId]
+      : [session.user.id];
 
-      const allowedOwners = user?.partnerId ? [session.user.id, user.partnerId] : [session.user.id];
-
-      const customCategory = await db.select()
-        .from(categories)
-        .where(eq(categories.id, validatedData.categoryId))
-        .limit(1);
-
-      if (customCategory.length === 0 || !allowedOwners.includes(customCategory[0].userId)) {
-        return NextResponse.json({ error: 'Invalid category' }, { status: 400 });
-      }
-    } else {
-      // Check if default category exists
-      const defaultCategory = DEFAULT_CATEGORIES.find(cat => cat.id === validatedData.categoryId);
-      if (!defaultCategory) {
-        return NextResponse.json({ error: 'Invalid category' }, { status: 400 });
-      }
+    if (!await canUseCategory({ categoryId: validatedData.categoryId, userIds })) {
+      return NextResponse.json({ error: 'Invalid category' }, { status: 400 });
     }
 
     const id = crypto.randomUUID();

--- a/components/forms/TransactionForm.tsx
+++ b/components/forms/TransactionForm.tsx
@@ -290,6 +290,11 @@ export function TransactionForm({
                             <span className="text-sm font-medium block truncate">
                               {getCategoryDisplayName(category, t)}
                             </span>
+                            {category.archivedAt && (
+                              <span className="block text-xs text-muted-foreground">
+                                {t('categories_archived_label')}
+                              </span>
+                            )}
                           </div>
                           <Badge
                             variant="outline"

--- a/hooks/useCategories.ts
+++ b/hooks/useCategories.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { Category, CategoryFormData } from '@/types';
 
 export class CategoryMutationError extends Error {
@@ -23,8 +23,9 @@ async function readMutationError(response: Response, fallback: string) {
   );
 }
 
-async function fetchCategories(): Promise<{ categories: Category[] }> {
-  const response = await fetch('/api/categories', {
+async function fetchCategories(includeArchived: boolean): Promise<{ categories: Category[] }> {
+  const searchParams = includeArchived ? '?includeArchived=true' : '';
+  const response = await fetch(`/api/categories${searchParams}`, {
     credentials: 'include',
   });
 
@@ -71,26 +72,53 @@ async function updateCategory(id: string, data: CategoryFormData): Promise<Categ
   return body.category;
 }
 
-async function deleteCategory(id: string): Promise<{ success: boolean }> {
+type DeleteCategoryResult = {
+  success: boolean;
+  archived: boolean;
+};
+
+async function deleteCategory(id: string): Promise<DeleteCategoryResult> {
   const response = await fetch(`/api/categories/${id}`, {
     method: 'DELETE',
     credentials: 'include',
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({ error: 'Failed to delete category' }));
-    throw new Error(errorData.error || 'Failed to delete category');
+    throw await readMutationError(response, 'Failed to delete category');
   }
 
   return response.json();
-
 }
 
+async function restoreCategory(id: string): Promise<Category> {
+  const response = await fetch(`/api/categories/${id}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+    body: JSON.stringify({ archived: false }),
+  });
 
-export function useCategories() {
+  if (!response.ok) {
+    throw await readMutationError(response, 'Failed to restore category');
+  }
+
+  const body = await response.json();
+  return body.category;
+}
+
+function invalidateCategoryData(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: ['categories'] });
+  queryClient.invalidateQueries({ queryKey: ['transactions'] });
+  queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+  queryClient.invalidateQueries({ queryKey: ['history'] });
+}
+
+export function useCategories({ includeArchived = false } = {}) {
   return useQuery({
-    queryKey: ['categories'],
-    queryFn: fetchCategories,
+    queryKey: ['categories', { includeArchived }],
+    queryFn: () => fetchCategories(includeArchived),
     staleTime: 10 * 60 * 1000, // 10 minutes
   });
 }
@@ -124,10 +152,18 @@ export function useDeleteCategory() {
   return useMutation({
     mutationFn: deleteCategory,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['categories'] });
-      queryClient.invalidateQueries({ queryKey: ['transactions'] });
-      queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-      queryClient.invalidateQueries({ queryKey: ['history'] });
+      invalidateCategoryData(queryClient);
+    },
+  });
+}
+
+export function useRestoreCategory() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: restoreCategory,
+    onSuccess: () => {
+      invalidateCategoryData(queryClient);
     },
   });
 }

--- a/lib/db/migrations/0008_flashy_skaar.sql
+++ b/lib/db/migrations/0008_flashy_skaar.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "categories" ADD COLUMN "archived_at" timestamp;

--- a/lib/db/migrations/meta/0008_snapshot.json
+++ b/lib/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,957 @@
+{
+  "id": "19ff0c44-a741-4473-b0f0-592674554f50",
+  "prevId": "a58a7d5a-d52f-416d-929e-36045e598eac",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_users_id_fk": {
+          "name": "account_user_id_users_id_fk",
+          "tableFrom": "account",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_created_by_users_id_fk": {
+          "name": "categories_created_by_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "type_check": {
+          "name": "type_check",
+          "value": "\"categories\".\"type\" IN ('income', 'expense')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.list_items": {
+      "name": "list_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_price": {
+          "name": "estimated_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_checked": {
+          "name": "is_checked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_items_list_id_lists_id_fk": {
+          "name": "list_items_list_id_lists_id_fk",
+          "tableFrom": "list_items",
+          "tableTo": "lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_items_created_by_users_id_fk": {
+          "name": "list_items_created_by_users_id_fk",
+          "tableFrom": "list_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_items_transaction_id_transactions_id_fk": {
+          "name": "list_items_transaction_id_transactions_id_fk",
+          "tableFrom": "list_items",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3B82F6'"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_shared": {
+          "name": "is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lists_user_id_users_id_fk": {
+          "name": "lists_user_id_users_id_fk",
+          "tableFrom": "lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lists_created_by_users_id_fk": {
+          "name": "lists_created_by_users_id_fk",
+          "tableFrom": "lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_invitations": {
+      "name": "partner_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "partner_invitations_from_user_id_users_id_fk": {
+          "name": "partner_invitations_from_user_id_users_id_fk",
+          "tableFrom": "partner_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "partner_invitations_to_user_id_users_id_fk": {
+          "name": "partner_invitations_to_user_id_users_id_fk",
+          "tableFrom": "partner_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "partner_invitations_token_unique": {
+          "name": "partner_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "status_check": {
+          "name": "status_check",
+          "value": "\"partner_invitations\".\"status\" IN ('pending', 'accepted', 'declined', 'expired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_users_id_fk": {
+          "name": "session_user_id_users_id_fk",
+          "tableFrom": "session",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_fixed": {
+          "name": "is_fixed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "repeat_type": {
+          "name": "repeat_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'once'"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month_key": {
+          "name": "month_key",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "EXTRACT(YEAR FROM \"date\")::int * 12 + EXTRACT(MONTH FROM \"date\")::int - 1",
+            "type": "stored"
+          }
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_month": {
+          "name": "end_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided": {
+          "name": "voided",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_series_month_unique": {
+          "name": "transactions_series_month_unique",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"transactions\".\"series_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_month_idx": {
+          "name": "transactions_user_month_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_created_by_users_id_fk": {
+          "name": "transactions_created_by_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "repeat_type_check": {
+          "name": "repeat_type_check",
+          "value": "\"transactions\".\"repeat_type\" IS NULL OR \"transactions\".\"repeat_type\" IN ('once', 'forever', '3months', '4months', '6months', '12months', 'until', 'annual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "partner_id": {
+          "name": "partner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1785081180021,
       "tag": "0007_canonical_category_identity",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1785085996351,
+      "tag": "0008_flashy_skaar",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -73,6 +73,7 @@ export const categories = pgTable('categories', {
   name: varchar('name', { length: 100 }).notNull(),
   type: varchar('type', { length: 20 }).notNull(),
   color: varchar('color', { length: 7 }).notNull(), // Hex color code
+  archivedAt: timestamp('archived_at'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
 }, (table) => ({
   typeCheck: check('type_check', sql`${table.type} IN ('income', 'expense')`)

--- a/lib/services/budget/budget.ts
+++ b/lib/services/budget/budget.ts
@@ -96,6 +96,7 @@ export async function getCategoryLookup(userIds: string[]): Promise<Record<strin
       isCustom: false,
       userId: null,
       createdAt: undefined,
+      archivedAt: null,
     };
   }
 
@@ -108,6 +109,7 @@ export async function getCategoryLookup(userIds: string[]): Promise<Record<strin
       isCustom: true,
       userId: cat.userId,
       createdAt: cat.createdAt,
+      archivedAt: cat.archivedAt,
     };
   }
 

--- a/lib/services/categories/access.ts
+++ b/lib/services/categories/access.ts
@@ -1,0 +1,37 @@
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { categories } from '@/lib/db/schema';
+import { isDefaultCategoryId } from '@/lib/default-category-identity';
+
+type CategoryAccessOptions = {
+  categoryId: string;
+  userIds: string[];
+  includeArchived?: boolean;
+};
+
+/**
+ * Categories can be shared inside a household, but archived categories must not be
+ * selected for new data. Existing records may keep their archived category while the
+ * user edits unrelated fields, which is what `includeArchived` is for.
+ */
+export async function canUseCategory({
+  categoryId,
+  userIds,
+  includeArchived = false,
+}: CategoryAccessOptions): Promise<boolean> {
+  if (isDefaultCategoryId(categoryId)) {
+    return true;
+  }
+
+  const [category] = await db
+    .select({ id: categories.id })
+    .from(categories)
+    .where(and(
+      eq(categories.id, categoryId),
+      inArray(categories.userId, userIds),
+      includeArchived ? undefined : isNull(categories.archivedAt)
+    ))
+    .limit(1);
+
+  return Boolean(category);
+}

--- a/lib/services/categories/lifecycle.test.ts
+++ b/lib/services/categories/lifecycle.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { shouldArchiveCategory } from './lifecycle';
+
+describe('shouldArchiveCategory', () => {
+  it('allows an unused category to be deleted permanently', () => {
+    expect(shouldArchiveCategory({
+      transactions: false,
+      lists: false,
+      listItems: false,
+    })).toBe(false);
+  });
+
+  it.each([
+    ['transaction', { transactions: true, lists: false, listItems: false }],
+    ['list', { transactions: false, lists: true, listItems: false }],
+    ['list item', { transactions: false, lists: false, listItems: true }],
+  ])('archives a category referenced by a %s', (_reference, references) => {
+    expect(shouldArchiveCategory(references)).toBe(true);
+  });
+});

--- a/lib/services/categories/lifecycle.ts
+++ b/lib/services/categories/lifecycle.ts
@@ -1,0 +1,13 @@
+export type CategoryReferences = {
+  transactions: boolean;
+  lists: boolean;
+  listItems: boolean;
+};
+
+/**
+ * Referenced categories are archived so historical records keep their identity.
+ * Categories that were never used can be removed permanently.
+ */
+export function shouldArchiveCategory(references: CategoryReferences): boolean {
+  return references.transactions || references.lists || references.listItems;
+}

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -237,15 +237,25 @@ export default {
   categories_expense: "expense",
   categories_loading_error: "Error loading categories",
   categories_login_required: "Please sign in to access categories",
-  categories_delete_title: "Delete category",
+  categories_delete_title: "Remove category",
   categories_delete_confirmation:
-    'Are you sure you want to delete the category "{name}"? This action cannot be undone.',
-  categories_delete: "Delete",
-  categories_deleting: "Deleting...",
+    'Remove the category "{name}"?',
+  categories_delete_archive_explanation:
+    "If it is used by existing data, it will be archived to preserve your history. Otherwise, it will be permanently deleted.",
+  categories_delete: "Remove",
+  categories_deleting: "Removing...",
   categories_delete_success: 'Category "{name}" deleted successfully.',
+  categories_archive_success: 'Category "{name}" archived successfully.',
   categories_delete_error: "Failed to delete category.",
   categories_delete_in_use_error:
     "Cannot delete this category because it is used by existing transactions.",
+  categories_archived_title: "Archived categories",
+  categories_archived_description:
+    "Archived categories remain in your history but cannot be selected for new items.",
+  categories_archived_label: "Archived",
+  categories_restore: "Restore",
+  categories_restore_success: 'Category "{name}" restored successfully.',
+  categories_restore_error: "Failed to restore category.",
 
   // Currencies
   currency_eur: "Euro - €",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -241,15 +241,25 @@ export default {
   categories_loading_error: "Erreur lors du chargement des catégories",
   categories_login_required:
     "Veuillez vous connecter pour accéder aux catégories",
-  categories_delete_title: "Supprimer la catégorie",
+  categories_delete_title: "Retirer la catégorie",
   categories_delete_confirmation:
-    'Êtes-vous sûr de vouloir supprimer la catégorie "{name}" ? Cette action ne peut pas être annulée.',
-  categories_delete: "Supprimer",
+    'Retirer la catégorie « {name} » ?',
+  categories_delete_archive_explanation:
+    "Si elle est utilisée par des données existantes, elle sera archivée pour préserver votre historique. Sinon, elle sera supprimée définitivement.",
+  categories_delete: "Retirer",
   categories_deleting: "Suppression...",
   categories_delete_success: 'Catégorie "{name}" supprimée avec succès.',
+  categories_archive_success: 'Catégorie « {name} » archivée avec succès.',
   categories_delete_error: "Échec de la suppression de la catégorie.",
   categories_delete_in_use_error:
     "Impossible de supprimer cette catégorie car elle est utilisée par des transactions existantes.",
+  categories_archived_title: "Catégories archivées",
+  categories_archived_description:
+    "Les catégories archivées restent dans votre historique mais ne peuvent plus être sélectionnées.",
+  categories_archived_label: "Archivée",
+  categories_restore: "Restaurer",
+  categories_restore_success: 'Catégorie « {name} » restaurée avec succès.',
+  categories_restore_error: "Échec de la restauration de la catégorie.",
 
   // Currencies
   currency_eur: "Euro - €",

--- a/types/index.ts
+++ b/types/index.ts
@@ -14,6 +14,7 @@ export type Category = {
   isCustom: boolean;
   userId?: string | null;
   createdAt?: Date;
+  archivedAt?: Date | null;
 };
 
 export type DatabaseCategory = InferSelectModel<typeof categories>;


### PR DESCRIPTION
## Summary
- archive custom categories that are still referenced by transactions, lists, or list items
- permanently delete only unused categories and allow archived categories to be restored
- hide archived categories from new transactions and lists while keeping historical labels intact
- preserve compatibility with existing mobile clients using the current categories API
- add the archived_at migration and lifecycle coverage

## UX
- the remove dialog explains whether a category will be archived or permanently deleted
- archived categories appear in a separate, restorable section
- partner-owned categories no longer expose unauthorized edit or remove actions
- old transactions keep showing their archived category while editing

## Verification
- pnpm type-check
- pnpm lint
- pnpm test (46 tests)
- pnpm db:check
- pnpm build:local