### PR TITLE
feat: add safe App Store screenshot seed

### DIFF
--- a/docs/app-store-screenshots.md
+++ b/docs/app-store-screenshots.md
@@ -1,0 +1,73 @@
+# App Store screenshot accounts
+
+Use the dedicated seed instead of a personal account. It creates a French and an
+English household, each with a generic partner, twelve months of realistic history,
+recurring transactions, planned expenses, custom categories, and shared lists.
+
+## Safety
+
+The seed resets only these reserved accounts:
+
+- `screenshots-en@demo.meffin.app`
+- `screenshots-en-partner@demo.meffin.app`
+- `screenshots-fr@demo.meffin.app`
+- `screenshots-fr-partner@demo.meffin.app`
+
+It refuses remote databases by default. Use a dedicated local, preview, or staging
+database—never the production database.
+
+## Run it
+
+Add a password of at least eight characters to `.env.local`:
+
+```dotenv
+SCREENSHOT_SEED_PASSWORD=replace-with-a-private-password
+```
+
+Preview the fixture without touching the database:
+
+```bash
+pnpm run seed:screenshots -- --dry-run
+```
+
+Seed both languages locally:
+
+```bash
+pnpm run db:migrate
+pnpm run seed:screenshots
+```
+
+Seed only one language:
+
+```bash
+pnpm run seed:screenshots -- --locale fr
+pnpm run seed:screenshots -- --locale en
+```
+
+For a dedicated remote preview database, explicitly opt in from `.env.local`:
+
+```dotenv
+SCREENSHOT_SEED_ALLOW_REMOTE=true
+```
+
+The primary login emails are `screenshots-fr@demo.meffin.app` and
+`screenshots-en@demo.meffin.app`. Both use `SCREENSHOT_SEED_PASSWORD`.
+
+## Capture checklist
+
+Capture the same seven states in French and English:
+
+1. Dashboard — monthly overview
+2. Transactions — income, expenses, and net balance
+3. Trends — history and six-month forecast
+4. Planner — upcoming recurring and planned expenses
+5. Shared lists — Lisbon trip
+6. Partner — connected household
+7. Categories — default and custom categories
+
+Before each language:
+
+1. Set the app language.
+2. Sign into the matching screenshot account.
+3. Keep the same month, device, appearance, and capture order.
+4. Hide simulator controls and any development overlays.

--- a/lib/fixtures/app-store-screenshots.test.ts
+++ b/lib/fixtures/app-store-screenshots.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAppStoreScreenshotFixture,
+  SCREENSHOT_ACCOUNTS,
+} from './app-store-screenshots';
+
+const now = new Date('2026-07-27T12:00:00.000Z');
+
+describe('App Store screenshot fixture', () => {
+  it('builds a complete, deterministic year in both locales', () => {
+    const english = buildAppStoreScreenshotFixture({
+      locale: 'en',
+      userId: 'user-en',
+      partnerId: 'partner-en',
+      now,
+    });
+    const french = buildAppStoreScreenshotFixture({
+      locale: 'fr',
+      userId: 'user-fr',
+      partnerId: 'partner-fr',
+      now,
+    });
+
+    expect(english.currentMonth - english.firstMonth).toBe(11);
+    expect(english.transactions).toHaveLength(french.transactions.length);
+    expect(new Set(english.transactions.map(row => row.id)).size)
+      .toBe(english.transactions.length);
+    expect(english.transactions.some(row => row.description === 'Salary')).toBe(true);
+    expect(french.transactions.some(row => row.description === 'Salaire')).toBe(true);
+    expect(english.listItems.some(item => item.estimatedPrice === null)).toBe(true);
+    expect(french.lists.every(list => list.isShared)).toBe(true);
+  });
+
+  it('uses reserved and distinct demo accounts', () => {
+    const emails = Object.values(SCREENSHOT_ACCOUNTS)
+      .flatMap(account => [account.email, account.partnerEmail]);
+
+    expect(new Set(emails).size).toBe(4);
+    expect(emails.every(email => email.endsWith('@demo.meffin.app'))).toBe(true);
+  });
+
+  it('keeps one occurrence per recurring series and month', () => {
+    const fixture = buildAppStoreScreenshotFixture({
+      locale: 'en',
+      userId: 'user-en',
+      partnerId: 'partner-en',
+      now,
+    });
+    const occurrences = fixture.transactions
+      .filter(row => row.seriesId)
+      .map(row => `${row.seriesId}:${row.date?.slice(0, 7)}`);
+
+    expect(new Set(occurrences).size).toBe(occurrences.length);
+  });
+});

--- a/lib/fixtures/app-store-screenshots.ts
+++ b/lib/fixtures/app-store-screenshots.ts
@@ -1,0 +1,414 @@
+import {
+  categories,
+  listItems,
+  lists,
+  transactions,
+} from '../db/schema';
+import {
+  currentMonthKey,
+  fromKey,
+  occurrenceDate,
+} from '../services/budget/keys';
+
+export type ScreenshotLocale = 'en' | 'fr';
+
+type TransactionInsert = typeof transactions.$inferInsert;
+type CategoryInsert = typeof categories.$inferInsert;
+type ListInsert = typeof lists.$inferInsert;
+type ListItemInsert = typeof listItems.$inferInsert;
+
+export const SCREENSHOT_ACCOUNTS = {
+  en: {
+    email: 'screenshots-en@demo.meffin.app',
+    name: 'Jamie Taylor',
+    partnerEmail: 'screenshots-en-partner@demo.meffin.app',
+    partnerName: 'Alex Taylor',
+  },
+  fr: {
+    email: 'screenshots-fr@demo.meffin.app',
+    name: 'Camille Martin',
+    partnerEmail: 'screenshots-fr-partner@demo.meffin.app',
+    partnerName: 'Alex Martin',
+  },
+} as const satisfies Record<ScreenshotLocale, {
+  email: string;
+  name: string;
+  partnerEmail: string;
+  partnerName: string;
+}>;
+
+const COPY = {
+  en: {
+    salary: 'Salary',
+    freelance: 'Freelance project',
+    rent: 'Rent',
+    internet: 'Internet',
+    streaming: 'Streaming',
+    gym: 'Gym',
+    insurance: 'Home insurance',
+    water: 'Water bill',
+    flights: 'Flights to Lisbon',
+    groceries: ['Weekly groceries', 'Farmers market', 'Supermarket'],
+    dining: ['Dinner with friends', 'Coffee and lunch', 'Sunday brunch'],
+    transport: ['Metro pass', 'Train tickets', 'Bike service'],
+    shopping: ['Running shoes', 'Home supplies', 'Bookshop'],
+    entertainment: ['Cinema', 'Concert tickets', 'Museum'],
+    travelCategory: 'Travel',
+    travelList: 'Lisbon trip',
+    travelListDescription: 'Everything we need for our weekend away',
+    groceriesList: 'Weekly groceries',
+    groceriesListDescription: 'Shared household shopping',
+    listItems: {
+      flights: 'Flight tickets',
+      hotel: 'Hotel',
+      guide: 'City guide',
+      passport: 'Check passports',
+      vegetables: 'Fresh vegetables',
+      coffee: 'Coffee',
+      pasta: 'Pasta',
+      detergent: 'Laundry detergent',
+    },
+  },
+  fr: {
+    salary: 'Salaire',
+    freelance: 'Mission freelance',
+    rent: 'Loyer',
+    internet: 'Internet',
+    streaming: 'Streaming',
+    gym: 'Salle de sport',
+    insurance: 'Assurance habitation',
+    water: "Facture d'eau",
+    flights: 'Billets pour Lisbonne',
+    groceries: ['Courses de la semaine', 'Marché', 'Supermarché'],
+    dining: ['Dîner entre amis', 'Café et déjeuner', 'Brunch du dimanche'],
+    transport: ['Pass métro', 'Billets de train', 'Révision du vélo'],
+    shopping: ['Chaussures de sport', 'Maison', 'Librairie'],
+    entertainment: ['Cinéma', 'Billets de concert', 'Musée'],
+    travelCategory: 'Voyages',
+    travelList: 'Week-end à Lisbonne',
+    travelListDescription: 'Tout préparer pour notre week-end',
+    groceriesList: 'Courses de la semaine',
+    groceriesListDescription: 'Liste partagée pour la maison',
+    listItems: {
+      flights: "Billets d'avion",
+      hotel: 'Hôtel',
+      guide: 'Guide de la ville',
+      passport: 'Vérifier les passeports',
+      vegetables: 'Légumes frais',
+      coffee: 'Café',
+      pasta: 'Pâtes',
+      detergent: 'Lessive',
+    },
+  },
+} as const;
+
+type BuildOptions = {
+  locale: ScreenshotLocale;
+  userId: string;
+  partnerId: string;
+  now?: Date;
+};
+
+type ScreenshotFixture = {
+  categories: CategoryInsert[];
+  transactions: TransactionInsert[];
+  lists: ListInsert[];
+  listItems: ListItemInsert[];
+  firstMonth: number;
+  currentMonth: number;
+};
+
+const HISTORY_MONTHS = 12;
+
+function stableId(locale: ScreenshotLocale, kind: string, suffix: string | number) {
+  return `screenshot-${locale}-${kind}-${suffix}`;
+}
+
+function monthLabel(key: number) {
+  const { year, month } = fromKey(key);
+  return `${year}-${String(month + 1).padStart(2, '0')}`;
+}
+
+export function buildAppStoreScreenshotFixture({
+  locale,
+  userId,
+  partnerId,
+  now = new Date(),
+}: BuildOptions): ScreenshotFixture {
+  const copy = COPY[locale];
+  const current = currentMonthKey(now);
+  const firstMonth = current - (HISTORY_MONTHS - 1);
+  const travelCategoryId = stableId(locale, 'category', 'travel');
+  const rows: TransactionInsert[] = [];
+
+  const baseTransaction = (
+    id: string,
+    ownerId: string,
+    description: string,
+    categoryId: string,
+    amount: number,
+    key: number,
+    day: number
+  ): TransactionInsert => ({
+    id,
+    userId: ownerId,
+    createdBy: ownerId,
+    categoryId,
+    description,
+    amount: amount.toFixed(2),
+    date: occurrenceDate(key, day),
+    isFixed: false,
+    isPrivate: false,
+    repeatType: 'once',
+  });
+
+  const addMonthlySeries = ({
+    key,
+    ownerId,
+    description,
+    categoryId,
+    amount,
+    day,
+    startsAt = firstMonth,
+    endMonth = null,
+  }: {
+    key: string;
+    ownerId: string;
+    description: string;
+    categoryId: string;
+    amount: number;
+    day: number;
+    startsAt?: number;
+    endMonth?: number | null;
+  }) => {
+    const seriesId = stableId(locale, 'series', key);
+
+    for (let month = startsAt; month <= current; month++) {
+      rows.push({
+        ...baseTransaction(
+          stableId(locale, 'transaction', `${key}-${monthLabel(month)}`),
+          ownerId,
+          description,
+          categoryId,
+          amount,
+          month,
+          day
+        ),
+        isFixed: true,
+        repeatType: endMonth === null ? 'forever' : 'until',
+        seriesId,
+        endMonth,
+        endDate: endMonth === null ? null : occurrenceDate(endMonth, day),
+      });
+    }
+  };
+
+  addMonthlySeries({
+    key: 'salary',
+    ownerId: userId,
+    description: copy.salary,
+    categoryId: 'default_salary',
+    amount: 3400,
+    day: 28,
+  });
+  addMonthlySeries({
+    key: 'freelance',
+    ownerId: partnerId,
+    description: copy.freelance,
+    categoryId: 'default_freelance',
+    amount: 720,
+    day: 12,
+  });
+  addMonthlySeries({
+    key: 'rent',
+    ownerId: userId,
+    description: copy.rent,
+    categoryId: 'default_housing',
+    amount: 1250,
+    day: 5,
+  });
+  addMonthlySeries({
+    key: 'internet',
+    ownerId: partnerId,
+    description: copy.internet,
+    categoryId: 'default_utilities',
+    amount: 39.99,
+    day: 15,
+  });
+  addMonthlySeries({
+    key: 'streaming',
+    ownerId: userId,
+    description: copy.streaming,
+    categoryId: 'default_subscriptions',
+    amount: 15.99,
+    day: 20,
+  });
+  addMonthlySeries({
+    key: 'gym',
+    ownerId: userId,
+    description: copy.gym,
+    categoryId: 'default_healthcare',
+    amount: 42,
+    day: 2,
+    startsAt: current - 5,
+    endMonth: current + 1,
+  });
+
+  const annualId = stableId(locale, 'series', 'insurance');
+  rows.push({
+    ...baseTransaction(
+      stableId(locale, 'transaction', 'insurance'),
+      userId,
+      copy.insurance,
+      'default_insurance',
+      420,
+      current + 2,
+      3
+    ),
+    isFixed: true,
+    repeatType: 'annual',
+    seriesId: annualId,
+  });
+
+  const variableAmounts = [
+    [86.4, 42, 78, 64, 25],
+    [94.2, 31, 78, 129, 38],
+    [72.6, 54, 45, 47, 22],
+    [105.8, 36, 78, 84, 32],
+  ];
+
+  for (let key = firstMonth; key <= current; key++) {
+    const index = (key - firstMonth) % variableAmounts.length;
+    const amounts = variableAmounts[index];
+    const ownerId = index % 2 === 0 ? userId : partnerId;
+
+    [
+      [copy.groceries[index % copy.groceries.length], 'default_groceries', amounts[0], 7],
+      [copy.dining[index % copy.dining.length], 'default_dining', amounts[1], 14],
+      [copy.transport[index % copy.transport.length], 'default_transportation', amounts[2], 9],
+      [copy.shopping[index % copy.shopping.length], 'default_shopping', amounts[3], 19],
+      [copy.entertainment[index % copy.entertainment.length], 'default_entertainment', amounts[4], 23],
+    ].forEach(([description, categoryId, amount, day], itemIndex) => {
+      rows.push(baseTransaction(
+        stableId(locale, 'transaction', `variable-${monthLabel(key)}-${itemIndex}`),
+        ownerId,
+        description as string,
+        categoryId as string,
+        amount as number,
+        key,
+        day as number
+      ));
+    });
+  }
+
+  rows.push(baseTransaction(
+    stableId(locale, 'transaction', 'planned-water'),
+    partnerId,
+    copy.water,
+    'default_utilities',
+    86.5,
+    current + 1,
+    14
+  ));
+  rows.push(baseTransaction(
+    stableId(locale, 'transaction', 'planned-flights'),
+    userId,
+    copy.flights,
+    travelCategoryId,
+    420,
+    current + 2,
+    9
+  ));
+
+  const travelListId = stableId(locale, 'list', 'travel');
+  const groceriesListId = stableId(locale, 'list', 'groceries');
+
+  return {
+    currentMonth: current,
+    firstMonth,
+    categories: [
+      {
+        id: travelCategoryId,
+        userId,
+        createdBy: userId,
+        name: copy.travelCategory,
+        type: 'expense',
+        color: '#14B8A6',
+      },
+    ],
+    transactions: rows,
+    lists: [
+      {
+        id: travelListId,
+        userId,
+        createdBy: userId,
+        title: copy.travelList,
+        description: copy.travelListDescription,
+        color: '#F97316',
+        categoryId: travelCategoryId,
+        isShared: true,
+      },
+      {
+        id: groceriesListId,
+        userId: partnerId,
+        createdBy: partnerId,
+        title: copy.groceriesList,
+        description: copy.groceriesListDescription,
+        color: '#10B981',
+        categoryId: 'default_groceries',
+        isShared: true,
+      },
+    ],
+    listItems: [
+      {
+        id: stableId(locale, 'item', 'flights'),
+        listId: travelListId,
+        createdBy: userId,
+        name: copy.listItems.flights,
+        estimatedPrice: '420.00',
+        categoryId: travelCategoryId,
+      },
+      {
+        id: stableId(locale, 'item', 'hotel'),
+        listId: travelListId,
+        createdBy: partnerId,
+        name: copy.listItems.hotel,
+        estimatedPrice: '310.00',
+        categoryId: travelCategoryId,
+      },
+      {
+        id: stableId(locale, 'item', 'guide'),
+        listId: travelListId,
+        createdBy: userId,
+        name: copy.listItems.guide,
+        estimatedPrice: '18.00',
+        categoryId: travelCategoryId,
+        isChecked: true,
+        checkedAt: occurrenceDate(current, 4),
+      },
+      {
+        id: stableId(locale, 'item', 'passport'),
+        listId: travelListId,
+        createdBy: partnerId,
+        name: copy.listItems.passport,
+        estimatedPrice: null,
+        categoryId: travelCategoryId,
+      },
+      ...[
+        [copy.listItems.vegetables, '24.00'],
+        [copy.listItems.coffee, '8.50'],
+        [copy.listItems.pasta, '5.20'],
+        [copy.listItems.detergent, '11.90'],
+      ].map(([name, estimatedPrice], index): ListItemInsert => ({
+        id: stableId(locale, 'item', `groceries-${index}`),
+        listId: groceriesListId,
+        createdBy: index % 2 === 0 ? userId : partnerId,
+        name,
+        estimatedPrice,
+        categoryId: 'default_groceries',
+        isChecked: index === 0,
+        checkedAt: index === 0 ? occurrenceDate(current, 4) : null,
+      })),
+    ],
+  };
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "db:dev": "drizzle-kit push --force",
     "db:studio": "drizzle-kit studio",
     "seed:demo": "tsx --env-file=.env.local scripts/seed-demo.ts",
+    "seed:screenshots": "tsx --env-file=.env.local scripts/seed-app-store-screenshots.ts",
     "db:check": "drizzle-kit check",
     "release": "bash scripts/release.sh"
   },

--- a/scripts/seed-app-store-screenshots.ts
+++ b/scripts/seed-app-store-screenshots.ts
@@ -1,0 +1,174 @@
+/**
+ * Creates isolated, resettable accounts for App Store and Play Store screenshots.
+ *
+ * The script only ever deletes the reserved accounts declared in
+ * `SCREENSHOT_ACCOUNTS`. Remote databases require an explicit opt-in.
+ */
+import { inArray, eq } from 'drizzle-orm';
+import {
+  buildAppStoreScreenshotFixture,
+  SCREENSHOT_ACCOUNTS,
+} from '@/lib/fixtures/app-store-screenshots';
+import type { ScreenshotLocale } from '@/lib/fixtures/app-store-screenshots';
+import {
+  categories,
+  listItems,
+  lists,
+  transactions,
+  users,
+} from '@/lib/db/schema';
+import { fromKey } from '@/lib/services/budget/keys';
+
+type Arguments = {
+  locales: ScreenshotLocale[];
+  dryRun: boolean;
+};
+
+function parseArguments(argv: string[]): Arguments {
+  const localeIndex = argv.indexOf('--locale');
+  const requestedLocale = localeIndex === -1 ? 'all' : argv[localeIndex + 1];
+
+  if (!['all', 'en', 'fr'].includes(requestedLocale)) {
+    throw new Error('Use --locale en, --locale fr, or --locale all.');
+  }
+
+  return {
+    locales: requestedLocale === 'all'
+      ? ['en', 'fr']
+      : [requestedLocale as ScreenshotLocale],
+    dryRun: argv.includes('--dry-run'),
+  };
+}
+
+function isLocalDatabase(databaseUrl: string) {
+  let hostname: string;
+  try {
+    hostname = new URL(databaseUrl).hostname;
+  } catch {
+    throw new Error('DATABASE_URL is not a valid PostgreSQL URL.');
+  }
+
+  return ['localhost', '127.0.0.1', '::1'].includes(hostname);
+}
+
+function assertSafeDatabase(databaseUrl: string) {
+  if (
+    !isLocalDatabase(databaseUrl) &&
+    process.env.SCREENSHOT_SEED_ALLOW_REMOTE !== 'true'
+  ) {
+    throw new Error(
+      'Refusing to seed a remote database. Use a dedicated preview/staging database ' +
+      'and set SCREENSHOT_SEED_ALLOW_REMOTE=true explicitly.'
+    );
+  }
+}
+
+function labelMonth(key: number) {
+  const { year, month } = fromKey(key);
+  return `${year}-${String(month + 1).padStart(2, '0')}`;
+}
+
+async function main() {
+  const args = parseArguments(process.argv.slice(2));
+
+  if (args.dryRun) {
+    for (const locale of args.locales) {
+      const fixture = buildAppStoreScreenshotFixture({
+        locale,
+        userId: `dry-run-${locale}-user`,
+        partnerId: `dry-run-${locale}-partner`,
+      });
+      console.log(
+        `${locale.toUpperCase()}: ${fixture.transactions.length} transactions, ` +
+        `${fixture.lists.length} lists, ${fixture.listItems.length} items, ` +
+        `${labelMonth(fixture.firstMonth)} → ${labelMonth(fixture.currentMonth)}`
+      );
+    }
+    return;
+  }
+
+  const databaseUrl = process.env.DATABASE_URL;
+  const password = process.env.SCREENSHOT_SEED_PASSWORD;
+
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required.');
+  }
+  if (!password || password.length < 8) {
+    throw new Error('SCREENSHOT_SEED_PASSWORD must contain at least 8 characters.');
+  }
+
+  assertSafeDatabase(databaseUrl);
+
+  const [{ db }, { auth }] = await Promise.all([
+    import('@/lib/db'),
+    import('@/lib/auth'),
+  ]);
+
+  for (const locale of args.locales) {
+    const account = SCREENSHOT_ACCOUNTS[locale];
+    const emails = [account.email, account.partnerEmail];
+
+    // Resetting these reserved accounts makes every run deterministic while
+    // limiting the destructive scope to data created by this script.
+    await db.delete(users).where(inArray(users.email, emails));
+
+    const primary = await auth.api.signUpEmail({
+      body: {
+        email: account.email,
+        name: account.name,
+        password,
+      },
+    });
+    const partner = await auth.api.signUpEmail({
+      body: {
+        email: account.partnerEmail,
+        name: account.partnerName,
+        password,
+      },
+    });
+
+    const fixture = buildAppStoreScreenshotFixture({
+      locale,
+      userId: primary.user.id,
+      partnerId: partner.user.id,
+    });
+
+    await db.transaction(async tx => {
+      await tx
+        .update(users)
+        .set({
+          partnerId: partner.user.id,
+          currency: 'EUR',
+          emailVerified: true,
+        })
+        .where(eq(users.id, primary.user.id));
+      await tx
+        .update(users)
+        .set({
+          partnerId: primary.user.id,
+          currency: 'EUR',
+          emailVerified: true,
+        })
+        .where(eq(users.id, partner.user.id));
+
+      await tx.insert(categories).values(fixture.categories);
+      await tx.insert(transactions).values(fixture.transactions);
+      await tx.insert(lists).values(fixture.lists);
+      await tx.insert(listItems).values(fixture.listItems);
+    });
+
+    console.log(`\n${locale.toUpperCase()} screenshot account`);
+    console.log(`  email        ${account.email}`);
+    console.log(`  partner      ${account.partnerName}`);
+    console.log(`  history      ${labelMonth(fixture.firstMonth)} → ${labelMonth(fixture.currentMonth)}`);
+    console.log(`  transactions ${fixture.transactions.length}`);
+    console.log(`  lists        ${fixture.lists.length}`);
+  }
+
+  console.log('\nThe password is the value of SCREENSHOT_SEED_PASSWORD.');
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add isolated French and English screenshot households with generic partner accounts
- seed 12 months of realistic history, recurring and planned transactions, custom categories, and shared lists
- make the seed deterministic and idempotent for its reserved demo accounts
- refuse remote database writes unless explicitly enabled
- document the capture workflow and add a dry-run mode

## Validation
- 49 tests passed
- TypeScript type-check passed
- ESLint passed for changed TypeScript files
- Next.js production build passed
- dry-run generated 129 transactions, 2 lists, and 8 items per locale